### PR TITLE
Add min-width and max-width options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Yaml:
 | title                     | string   | Empty         | *                      | Title (Not displayed if using Title-Card)             |
 | clear                     | boolean  | _false_       | true\|false            | Remove Background                                     |
 | expanded                  | boolean  | _false_       | true\|false            | Start expanded                                        |
+| min-width-expanded        | number   | 0             | number                 | Min screen width (px) to be expanded on start (use with start expanded above)                                     |
+| max-width-expanded        | number   | 0             | number            | Max screen width (px) to be expanded on start (use with start expanded above)                                        |
 | expander-card-background  | string   | ha-card-background, card-background-color,#fff | css-color              | Expander Card Background |
 | header-color              | string   | primary-text-color,#fff  | css-color   | Color of expand button                     |
 | button-background         | string   | _transparent_ | css-color              | Background color of expand button                     |

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -57,23 +57,20 @@
         if (isEditorMode) {
             open = true;
         } else {
+            const minWidthExpanded = config['min-width-expanded'] as number;
+            const maxWidthExpanded = config['max-width-expanded'] as number;
+            const offsetWidth = document.body.offsetWidth;
+
+            if (minWidthExpanded && maxWidthExpanded) {
+                config.expanded = offsetWidth >= minWidthExpanded && offsetWidth <= maxWidthExpanded;
+            } else if (minWidthExpanded) {
+                config.expanded = offsetWidth >= minWidthExpanded;
+            } else if (maxWidthExpanded) {
+                config.expanded = offsetWidth <= maxWidthExpanded;
+            }
+
             if (config.expanded !== undefined) {
-                const min_width_expanded = config['min-width-expanded'] as number;
-                const max_width_expanded = config['max-width-expanded'] as number;
-                const offsetWidth = document.body.offsetWidth;
-
-                if (min_width_expanded && max_width_expanded) {
-                    config.expanded = offsetWidth >= min_width_expanded && offsetWidth <= max_width_expanded;
-                } else if (min_width_expanded) {
-                    config.expanded = offsetWidth >= min_width_expanded;
-                } else if (max_width_expanded) {
-                    config.expanded = offsetWidth <= max_width_expanded;
-                }
-
-                setTimeout(() => {
-                    open = config.expanded as boolean;
-                    config.expanded = undefined;
-                }, 100);
+                setTimeout(() => (open = config.expanded as boolean), 100);
             }
         }
     });

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -37,7 +37,9 @@
         'header-color': 'var(--primary-text-color,#fff)',
         'arrow-color': 'var(--arrow-color,var(--primary-text-color,#fff))',
         'expander-card-display': 'block',
-        'title-card-clickable': false
+        'title-card-clickable': false,
+        'min-width-expanded': 0,
+        'max-width-expanded': 0
     };
 
     let config: ExpanderConfig = defaults;
@@ -56,7 +58,22 @@
             open = true;
         } else {
             if (config.expanded !== undefined) {
-                setTimeout(() => (open = config.expanded as boolean), 100);
+                const min_width_expanded = config['min-width-expanded'] as number;
+                const max_width_expanded = config['max-width-expanded'] as number;
+                const offsetWidth = document.body.offsetWidth;
+
+                if (min_width_expanded && max_width_expanded) {
+                    config.expanded = offsetWidth >= min_width_expanded && offsetWidth <= max_width_expanded;
+                } else if (min_width_expanded) {
+                    config.expanded = offsetWidth >= min_width_expanded;
+                } else if (max_width_expanded) {
+                    config.expanded = offsetWidth <= max_width_expanded;
+                }
+
+                setTimeout(() => {
+                    open = config.expanded as boolean;
+                    config.expanded = undefined;
+                }, 100);
             }
         }
     });

--- a/src/ExpanderCardEditor.svelte
+++ b/src/ExpanderCardEditor.svelte
@@ -45,6 +45,12 @@ limitations under the License.
         'expanded': ['boolean', {
             label: 'Start expanded (Always expanded in editor)'
         }],
+        'min-width-expanded': ['number', {
+            label: 'Min screen width (px) to be expanded on start (use with start expanded above)'
+        }],
+        'max-width-expanded': ['number', {
+            label: 'Max screen width (px) to be expanded on start (use with start expanded above)'
+        }],
         'expander-card-background': ['string', {
             label: 'Expander Card Background (CSS color)'
         }],
@@ -198,6 +204,17 @@ limitations under the License.
                     configValue={config[key]}
                     on:input={passEv((ev) => {
                         config[key] = ev?.target?.value;
+                    })}
+                />
+            {/if}
+            {#if type === 'number' && (!extra?.cond || extra?.cond(config))}
+                <ha-textfield
+                    label={extra?.label || key}
+                    value={config[key] ?? ''}
+                    configValue={config[key]}
+                    type="number"
+                    on:input={passEv((ev) => {
+                        config[key] = parseInt(ev?.target?.value);
                     })}
                 />
             {/if}

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -32,4 +32,6 @@ export interface ExpanderConfig {
     'button-background': string;
     'arrow-color'?: string;
     'expander-card-display'?: string;
+    'min-width-expanded'?: number;
+    'max-width-expanded'?: number;
 }


### PR DESCRIPTION
Hi 👋🏻 

This PR adds support for the feature requested in #140 by @S1M8N.

Your latest commits with the listener seems to have magically fixed the only bug I had with the card not being expandable when the screen size changed, go figure hahaha.

This PR adds 2 settings in the editor, min-width and max-width. They must be used along the start expanded toggle.
If a min-width is specified, the card will only open when the screen width is >= to that value.
Same goes for max-width, the card will only open when the screen width is <= to that value.
They can be set individually or both at the same time.

If none are set, the behaviour of start expanded is not changed. 

I've also changed the type from string to number as reported in the request.

I'll let you test and report if you have any questions/improvements in mind :)

Have a great day 🎉 

Fix #140 