### PR TITLE
feat: add storage id config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Yaml Options:
 | title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                 |
 | title-card-clickable      | boolean  | _false_       | true\|false            | Should the complete diff clickable?                   |
 | overlay-margin            | string   | _0.0em_       | css-size               | Margin from top right of expander button (if overlay) |
+| storgage-id               | string   | **optional**  | *                      | Save last expander state in local browser storage     |
 | cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                     |
 | expander-card-display     | string   | block         | css-display            | Layout/Display of the card                            |
 

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -48,8 +48,8 @@
     let touchPreventClick = $state(false);
     let open = $state(false);
 
-    const configId = config['expand-id'];
-    const lastStorageOpenStateId = "expander-open-" + configId;
+    const configId = config['storgage-id'];
+    const lastStorageOpenStateId = 'expander-open-' + configId;
 
 
     function toggleOpen() {
@@ -60,10 +60,10 @@
         open = openState;
         if (configId !== undefined) {
             try {
-                    localStorage.setItem(lastStorageOpenStateId, open ? 'true' : 'false');
-                } catch (e) {
-                    console.error(e);
-                }
+                localStorage.setItem(lastStorageOpenStateId, open ? 'true' : 'false');
+            } catch (e) {
+                console.error(e);
+            }
         }
     }
 
@@ -80,12 +80,22 @@
             config.expanded = offsetWidth <= maxWidthExpanded;
         }
 
-        if (config.expanded !== undefined) {
-            setOpenState(config.expanded);
-        }
-
         if (configId !== undefined) {
-     
+            try {
+                const storageValue = localStorage.getItem(lastStorageOpenStateId);
+                if(storageValue === null){
+                    // first time, set the state from config
+                    if (config.expanded !== undefined) {
+                        setOpenState(config.expanded);
+                    }
+                }
+                else {
+                    // last state is stored in local storage
+                    open = storageValue ? storageValue === 'true' : open;
+                }
+            } catch (e) {
+                console.error(e);
+            }
         }
     });
 

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -48,6 +48,25 @@
     let touchPreventClick = $state(false);
     let open = $state(false);
 
+    const configId = config['expand-id'];
+    const lastStorageOpenStateId = "expander-open-" + configId;
+
+
+    function toggleOpen() {
+        setOpenState(!open);
+    }
+
+    function setOpenState(openState: boolean) {
+        open = openState;
+        if (configId !== undefined) {
+            try {
+                    localStorage.setItem(lastStorageOpenStateId, open ? 'true' : 'false');
+                } catch (e) {
+                    console.error(e);
+                }
+        }
+    }
+
     onMount(() => {
         const minWidthExpanded = config['min-width-expanded'];
         const maxWidthExpanded = config['max-width-expanded'];
@@ -62,7 +81,11 @@
         }
 
         if (config.expanded !== undefined) {
-            setTimeout(() => (open = config.expanded), 100);
+            setOpenState(config.expanded);
+        }
+
+        if (configId !== undefined) {
+     
         }
     });
 
@@ -73,7 +96,7 @@
             touchPreventClick = false;
             return false;
         }
-        open = !open;
+        toggleOpen();
     };
 
     const buttonClickDiv = (event: MouseEvent) => {
@@ -103,7 +126,7 @@
 
     const touchEnd = (event: TouchEvent) => {
         if (!isScrolling && touchElement === event.target && config['title-card-clickable']) {
-            open = !open;
+            toggleOpen();
         }
         touchElement = undefined;
         touchPreventClick = true;


### PR DESCRIPTION
A new feature has been added to allow saving the last expander state using a configuration option called `storage-id`. This configuration stores the state in the local browser storage, so that when a user revisits the page, the previous expansion or collapse states of elements are automatically restored. This enhances user experience by remembering their preferences and keeping the interface consistent with their last interactions.