### PR TITLE
Icon in a button

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Yaml Options:
 | ------------------------- | -------- | ------------- | ---------------------- | ----------------------------------------------------- |
 | type                      | string   | **Required**  | `custom:expander-card` | Type of the card.                                     |
 | title                     | string   | Empty         | *                      | Title (Not displayed if using Title-Card)             |
+| icon                      | string   | mdi:chevron-down         | mdi icon shortcut                      | Icon in button           |
 | clear                     | boolean  | _false_       | true\|false            | Remove Background                                     |
 | expanded                  | boolean  | _false_       | true\|false            | Start expanded                                        |
 | min-width-expanded        | number   | 0             | number                 | Min screen width (px) to be expanded on start (use with start expanded above)                                     |

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -15,7 +15,8 @@
             'expander-card-display': 'block',
             'title-card-clickable': false,
             'min-width-expanded': 0,
-            'max-width-expanded': 0
+            'max-width-expanded': 0,
+            'icon': 'mdi:chevron-down'
         };
 </script>
 
@@ -169,7 +170,7 @@
                 class={`header ripple${config['title-card-button-overlay'] ? ' header-overlay' : ''}${open ? ' open' : ' close'}`}
                 aria-label="Toggle button"
             >
-                <ha-icon style="--arrow-color:{config['arrow-color']}" icon="mdi:chevron-down" class={`ico${open ? ' flipped open' : 'close'}`} ></ha-icon>
+                <ha-icon style="--arrow-color:{config['arrow-color']}" icon="{config.icon}" class={`ico${open ? ' flipped open' : 'close'}`} ></ha-icon>
             </button>
         </div>
     {:else}
@@ -178,7 +179,7 @@
             style="--header-width:100%; --button-background:{config['button-background']};--header-color:{config['header-color']};"
         >
             <div class={`primary title${open ? ' open' : ' close'}`}>{config.title}</div>
-            <ha-icon style="--arrow-color:{config['arrow-color']}" icon="mdi:chevron-down" class={`ico${open ? ' flipped open' : ' close'}`}></ha-icon>
+            <ha-icon style="--arrow-color:{config['arrow-color']}" icon="{config.icon}" class={`ico${open ? ' flipped open' : ' close'}`}></ha-icon>
         </button>
     {/if}
     {#if config.cards}

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -35,4 +35,5 @@ export interface ExpanderConfig {
     'expander-card-display'?: string;
     'min-width-expanded'?: number;
     'max-width-expanded'?: number;
+    icon?: string;
 }


### PR DESCRIPTION
Added ability to use a different icon than mdi:chevron-down in a button by adding the icon: parameter in the card configuration. If the parameter is not given, mdi:chevron-down is used.