### PR TITLE
Fix CSS styling typo boxShadow > box-shadow

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -108,7 +108,7 @@ limitations under the License.
                 haCards.forEach((card) => {
                     card.style.setProperty('border', 'none', 'important');
                     card.style.setProperty('background', 'transparent', 'important');
-                    card.style.setProperty('boxShadow', 'none', 'important');
+                    card.style.setProperty('box-shadow', 'none', 'important');
                 });
             } else {
                 attempts++;


### PR DESCRIPTION
For the new "clear-children" config setting to work properly (it currently removes the border and background, but not box-shadow due to the typo). Great addition btw, which will allow me to remove lot of card-mod code ! 

Additional clarification: I believe the syntax could be either
`card.style.boxShadow = 'value'`
or
`card.style.setProperty('box-shadow', 'value')`   (I propose this one for readability and consistency with the rest) 
but not 
`card.style.setProperty('boxShadow', 'value')`
as currently set.  
