### PR TITLE
fix: Configuration option typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Yaml Options:
 | title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                 |
 | title-card-clickable      | boolean  | _false_       | true\|false            | Should the complete diff clickable?                   |
 | overlay-margin            | string   | _0.0em_       | css-size               | Margin from top right of expander button (if overlay) |
-| storgage-id               | string   | **optional**  | *                      | Save last expander state in local browser storage     |
+| storage-id                | string   | **optional**  | *                      | Save last expander state in local browser storage     |
 | cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                     |
 | expander-card-display     | string   | block         | css-display            | Layout/Display of the card                            |
 | icon-rotate-degree        | string   | _180deg_      | css-rotate             | Changing the degrees of the button icon when clicked  |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Yaml Options:
 | show-button-users         | object[] | **optional**  | *                      | Choose the users that button is visible to them       |
 | start-expanded-users      | object[] | **optional**  | *                      | Choose the users that card will be start expanded for them|
 
+
+### Deprecation Warning
+* `storgage-id` was introduced in v2.5.0 and is deprecated in favor of `storage-id`. The older `storgage-id` will be removed in a future release.
+
 ## Examples
 
 Here are a few examples of usage.

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -51,7 +51,7 @@
     let touchPreventClick = $state(false);
     let open = $state(false);
 
-    const configId = config['storgage-id'];
+    const configId = config['storage-id'] ?? config['storgage-id'];
     const lastStorageOpenStateId = 'expander-open-' + configId;
     const showButtonUsers = (config['show-button-users'] === undefined || config['show-button-users']?.includes(hass?.user.name));
 

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -37,6 +37,7 @@ export interface ExpanderConfig {
     'min-width-expanded'?: number;
     'max-width-expanded'?: number;
     icon?: string;
+    'storgage-id'?: string;  // Deprecated as of 2.6.5
     'storage-id'?: string;
     'icon-rotate-degree'?: string;
     'show-button-users'?: { type: string }[];

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -37,7 +37,7 @@ export interface ExpanderConfig {
     'min-width-expanded'?: number;
     'max-width-expanded'?: number;
     icon?: string;
-    'storgage-id'?: string;
+    'storage-id'?: string;
     'icon-rotate-degree'?: string;
     'show-button-users'?: { type: string }[];
     'start-expanded-users'?: { type: string }[];


### PR DESCRIPTION
There is a typo in the configuration option key: it is currently written as "storgage-id" instead of "storage-id." Both versions of the option will be supported as a transition until the end of this year. After that, the deprecated "storgage-id" option will be removed. Therefore, all users are strongly encouraged to update their configurations to use the correct "storage-id" key as soon as possible.