### PR TITLE
Expanding animation

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -19,8 +19,6 @@ limitations under the License.
     import type { LovelaceCard, HomeAssistant, LovelaceCardConfig } from 'custom-card-helpers';
     import { getCardUtil } from './cardUtil.svelte';
     import { onMount } from 'svelte';
-    import { slide } from 'svelte/transition';
-    import { cubicOut } from 'svelte/easing';
 
     const {
         type = 'div',
@@ -123,8 +121,8 @@ limitations under the License.
 
 </script>
 
-<div class="outer-container" style="margin-top: {open ? marginTop : '0px'};">
-    <svelte:element this={type} bind:this={container} transition:slide={{ duration: 500, easing: cubicOut }} />
+<div class="outer-container{open ? ' open' : ' close'}" style="margin-top: {open ? marginTop : '0px'};">
+    <svelte:element this={type} bind:this={container}/>
     {#if loading}
         <span class="loading"> Loading... </span>
     {/if}
@@ -136,5 +134,26 @@ limitations under the License.
     padding: 1em;
     display: block;
   }
-
+  .outer-container.open {
+    animation: fadeInOpacity 0.5s forwards ease;
+    -webkit-animation: fadeInOpacity 0.5s forwards ease;
+  }
+  @keyframes fadeInOpacity {
+      0% {
+          opacity: 0;
+      }
+      100% {
+          opacity: 1;
+      }
+  }
+  @-webkit-keyframes fadeInOpacity {
+      0% {
+          opacity: 0;
+          transform: translateY(-10%);
+      }
+      100% {
+          opacity: 1;
+          transform: translateY(0);
+      }
+  }
 </style>

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -19,6 +19,7 @@ limitations under the License.
     import type { LovelaceCard, HomeAssistant, LovelaceCardConfig } from 'custom-card-helpers';
     import { getCardUtil } from './cardUtil.svelte';
     import { onMount } from 'svelte';
+    import type { AnimationState } from './types';
 
     const {
         type = 'div',
@@ -26,8 +27,9 @@ limitations under the License.
         hass,
         marginTop ='0px',
         open,
+        animationState,
         clearCardCss = false
-    }: { type?: string; config: LovelaceCardConfig; hass: HomeAssistant | undefined; marginTop?: string; open: boolean; clearCardCss: boolean} = $props();
+    }: { type?: string; config: LovelaceCardConfig; hass: HomeAssistant | undefined; marginTop?: string; open: boolean; animationState: AnimationState; clearCardCss: boolean} = $props();
 
 
     let container = $state<LovelaceCard>();
@@ -121,7 +123,7 @@ limitations under the License.
 
 </script>
 
-<div class="outer-container{open ? ' open' : ' close'}" style="margin-top: {open ? marginTop : '0px'};">
+<div class="outer-container {animationState}" style="margin-top: {open ? marginTop : '0px'};">
     <svelte:element this={type} bind:this={container}/>
     {#if loading}
         <span class="loading"> Loading... </span>
@@ -134,9 +136,13 @@ limitations under the License.
     padding: 1em;
     display: block;
   }
-  .outer-container.open {
+  .outer-container.opening {
     animation: fadeInOpacity 0.5s forwards ease;
     -webkit-animation: fadeInOpacity 0.5s forwards ease;
+  }
+  .outer-container.closing {
+      animation: fadeOutOpacity 0.5s forwards ease;
+      -webkit-animation: fadeOutOpacity 0.5s forwards ease;
   }
   @keyframes fadeInOpacity {
       0% {
@@ -149,11 +155,25 @@ limitations under the License.
   @-webkit-keyframes fadeInOpacity {
       0% {
           opacity: 0;
-          transform: translateY(-10%);
       }
       100% {
           opacity: 1;
-          transform: translateY(0);
+      }
+  }
+    @keyframes fadeOutOpacity {
+      0% {
+          opacity: 1;
+      }
+      100% {
+          opacity: 0;
+      }
+  }
+  @-webkit-keyframes fadeOutOpacity {
+      0% {
+          opacity: 1;
+      }
+      100% {
+          opacity: 0;
       }
   }
 </style>

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -29,8 +29,15 @@ limitations under the License.
         open,
         animationState,
         clearCardCss = false
-    }: { type?: string; config: LovelaceCardConfig; hass: HomeAssistant | undefined; marginTop?: string; open: boolean; animationState: AnimationState; clearCardCss: boolean} = $props();
-
+    }: {
+        type?: string;
+        config: LovelaceCardConfig;
+        hass: HomeAssistant | undefined;
+        marginTop?: string;
+        open: boolean;
+        animationState: AnimationState;
+        clearCardCss: boolean;
+    } = $props();
 
     let container = $state<LovelaceCard>();
     let loading = $state(true);

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -130,7 +130,7 @@ limitations under the License.
 
 </script>
 
-<div class="outer-container {animationState}" style="margin-top: {open ? marginTop : '0px'};">
+<div class="outer-container{open ? ' open' : ' close'} {animationState}" style="margin-top: {open ? marginTop : '0px'};">
     <svelte:element this={type} bind:this={container}/>
     {#if loading}
         <span class="loading"> Loading... </span>

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -143,6 +143,17 @@ limitations under the License.
     padding: 1em;
     display: block;
   }
+  .outer-container {
+    transition: margin-bottom 0.35s ease;
+  }
+  .outer-container.open,
+  .outer-container.opening {
+    margin-bottom: inherit;
+  }
+  .outer-container.close,
+  .outer-container.closing {
+    margin-bottom: -100%;
+  }
   .outer-container.opening {
     animation: fadeInOpacity 0.5s forwards ease;
     -webkit-animation: fadeInOpacity 0.5s forwards ease;

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -227,7 +227,7 @@
             <div
                 style="--expander-card-display:{config['expander-card-display']};
                 --gap:{open ? config['expanded-gap'] : config.gap}; --child-padding:{open ? config['child-padding'] : '0px'};"
-                class="children-container {animationState}"
+                class="children-container"
             >
                 {#each config.cards as card (card)}
                     <Card hass={hass}
@@ -258,16 +258,6 @@
         padding: var(--child-padding);
         display: var(--expander-card-display,block);
         gap: var(--gap);
-    }
-    .children-container.opening {
-        animation: slide-in 0.35s forwards ease;
-        -webkit-animation: slide-in 0.35s forwards ease;
-    }
-    .children-container.closing {
-        translate: translateY(-100%);
-        -webkit-translate: translateY(-100%);
-        animation: slide-out 0.35s forwards ease;
-        -webkit-animation: slide-out 0.35s forwards ease;
     }
     .clear {
         background: none !important;

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -40,8 +40,8 @@
     import Card from './Card.svelte';
     import { onMount } from 'svelte';
     import type { ExpanderConfig } from './configtype';
-    import { slide } from 'svelte/transition';
-    import { cubicOut } from 'svelte/easing';
+    // import { slide } from 'svelte/transition';
+    // import { cubicOut } from 'svelte/easing';
 
     const {
         hass,
@@ -202,21 +202,22 @@
         {/if}
     {/if}
     {#if config.cards}
-        <div
-            style="--expander-card-display:{config['expander-card-display']};
-             --gap:{open ? config['expanded-gap'] : config.gap}; --child-padding:{open ? config['child-padding'] : '0px'};"
-            class="children-container"
-            transition:slide={{ duration: 500, easing: cubicOut }}
-        >
-            {#each config.cards as card (card)}
-                <Card hass={hass}
-                    config={card}
-                    type={card.type}
-                    marginTop={config['child-margin-top']}
-                    open={open}
-                    clearCardCss={config['clear-children'] || false}
-                />
-            {/each}
+        <div class="children-wrapper">
+            <div
+                style="--expander-card-display:{config['expander-card-display']};
+                --gap:{open ? config['expanded-gap'] : config.gap}; --child-padding:{open ? config['child-padding'] : '0px'};"
+                class="children-container{open ? ' open' : ' close'}"
+            >
+                {#each config.cards as card (card)}
+                    <Card hass={hass}
+                        config={card}
+                        type={card.type}
+                        marginTop={config['child-margin-top']}
+                        open={open}
+                        clearCardCss={config['clear-children'] || false}
+                    />
+                {/each}
+            </div>
         </div>
     {/if}
 </ha-card>
@@ -228,11 +229,21 @@
         padding: var(--padding);
         background: var(--card-background,#fff);
     }
+    .children-wrapper {
+        overflow: hidden;
+    }
     .children-container {
         padding: var(--child-padding);
         display: var(--expander-card-display,block);
         gap: var(--gap);
-        transition: all 0.3s ease-in-out;
+    }
+    .children-container.open {
+        animation: slide-in 0.35s forwards ease;
+        -webkit-animation: slide-in 0.35s forwards ease;
+    }
+    .children-container.close{
+        transform: translateY(-100%);
+        -webkit-transform: translateY(-100%);
     }
     .clear {
         background: none !important;
@@ -296,5 +307,13 @@
         background-color: #ffffff25;
         background-size: 100%;
         transition: background 0s;
+    }
+    @keyframes slide-in {
+        0% { transform: translateY(-100%); }
+        100% { transform: translateY(0%); }
+    }
+    @-webkit-keyframes slide-in {
+        0% { -webkit-transform: translateY(-100%); }
+        100% { -webkit-transform: translateY(0%); }
     }
 </style>

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -69,13 +69,13 @@
             animationTimeout = setTimeout(() => {
                 animationState = 'idle';
                 animationTimeout = null;
-            }, 500);
+            }, 350);
         } else {
             animationTimeout = setTimeout(() => {
                 setOpenState(false);
                 animationState = 'idle';
                 animationTimeout = null;
-            }, 500);
+            }, 350);
         }
     }
 

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -40,8 +40,6 @@
     import Card from './Card.svelte';
     import { onMount } from 'svelte';
     import type { ExpanderConfig } from './configtype';
-    // import { slide } from 'svelte/transition';
-    // import { cubicOut } from 'svelte/easing';
 
     const {
         hass,

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -217,7 +217,8 @@
                 style="--header-width:100%; --button-background:{config['button-background']};--header-color:{config['header-color']};"
             >
                 <div class={`primary title${open ? ' open' : ' close'}`}>{config.title}</div>
-                <ha-icon style="--arrow-color:{config['arrow-color']}" icon={config.icon} class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'}`}></ha-icon>
+                <ha-icon style="--arrow-color:{config['arrow-color']}"
+                  icon={config.icon} class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'}`}></ha-icon>
             </button>
         {/if}
     {/if}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+/*
+Copyright 2021-2022 Peter Repukat - FlatspotSoftware
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type AnimationState = 'opening' | 'closing' | 'idle';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,1 @@
-/*
-Copyright 2021-2022 Peter Repukat - FlatspotSoftware
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 export type AnimationState = 'opening' | 'closing' | 'idle';


### PR DESCRIPTION
Expander Animations #580 

This gives opening animation. As when closed, the cards will be removed straight away then there is nothing to animate. It may be possible to have a 'closing' state with a timeout (set CSS class straight away but delay 'close' for cards) but then need to handle case of quickly closing and opening, cancelling the timeout etc. So could only be halfway there but you get the general idea of how this needs to be accomplished.

Also, there is a extra div wrapper so the translateY does not overflow to the header. Not sure if ths may break anyone doing card-mods, but probably not as they would have used the direct selector for the .children-container.