### PR TITLE
fix: Icon animation late on collapse when using title-card

### DIFF
--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -206,7 +206,8 @@
                     class={`header ripple${config['title-card-button-overlay'] ? ' header-overlay' : ''}${open ? ' open' : ' close'}`}
                     aria-label="Toggle button"
                 >
-                    <ha-icon style="--arrow-color:{config['arrow-color']}" icon={config.icon} class={`ico${open ? ' flipped open' : ' close'}`} ></ha-icon>
+                    <ha-icon style="--arrow-color:{config['arrow-color']}"
+                      icon={config.icon} class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'}`}></ha-icon>
                 </button>
             {/if}
         </div>


### PR DESCRIPTION
Did not add `closing` class on icon in title-card case when doing animation. This PR fixes that.

Fixes #635 