### PR TITLE
fix: Improved animation and `animation: TRUE|false` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Yaml Options:
 | icon-rotate-degree        | string   | _180deg_      | css-rotate             | Changing the degrees of the button icon when clicked  |
 | show-button-users         | object[] | **optional**  | *                      | Choose the users that button is visible to them       |
 | start-expanded-users      | object[] | **optional**  | *                      | Choose the users that card will be start expanded for them|
+| animation                 | boolean   | _true_       | true\|false            | Should the opening/closing of expander be animated? |
 
 
 ### Deprecation Warning

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -18,7 +18,8 @@
             'min-width-expanded': 0,
             'max-width-expanded': 0,
             'icon': 'mdi:chevron-down',
-            'icon-rotate-degree': '180deg'
+            'icon-rotate-degree': '180deg',
+            'animation': true
         };
 </script>
 
@@ -63,19 +64,24 @@
             animationTimeout  = null;
         }
         const openState = !open;
-        animationState = openState ? 'opening' : 'closing';
-        if (openState) {
-            setOpenState(true);
-            animationTimeout = setTimeout(() => {
-                animationState = 'idle';
-                animationTimeout = null;
-            }, 350);
+        if (config.animation) {
+            animationState = openState ? 'opening' : 'closing';
+            if (openState) {
+                setOpenState(true);
+                animationTimeout = setTimeout(() => {
+                    animationState = 'idle';
+                    animationTimeout = null;
+                }, 350);
+            } else {
+                animationTimeout = setTimeout(() => {
+                    setOpenState(false);
+                    animationState = 'idle';
+                    animationTimeout = null;
+                }, 350);
+            }
         } else {
-            animationTimeout = setTimeout(() => {
-                setOpenState(false);
-                animationState = 'idle';
-                animationTimeout = null;
-            }, 350);
+            setOpenState(openState);
+            // animation state is always 'idle' if no animation
         }
     }
 
@@ -193,6 +199,7 @@
                 <Card hass={hass}
                     config={config['title-card']}
                     type={config['title-card'].type}
+                    animation={false}
                     open={true}
                     animationState='idle'
                     clearCardCss={config['clear-children'] || false}
@@ -207,7 +214,9 @@
                     aria-label="Toggle button"
                 >
                     <ha-icon style="--arrow-color:{config['arrow-color']}"
-                      icon={config.icon} class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'}`}></ha-icon>
+                      icon={config.icon}
+                      class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'} ${config.animation ? 'animation' : ''}`}>
+                    </ha-icon>
                 </button>
             {/if}
         </div>
@@ -219,7 +228,9 @@
             >
                 <div class={`primary title${open ? ' open' : ' close'}`}>{config.title}</div>
                 <ha-icon style="--arrow-color:{config['arrow-color']}"
-                  icon={config.icon} class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'}`}></ha-icon>
+                  icon={config.icon}
+                  class={`ico${open && animationState !=='closing' ? ' flipped open' : ' close'} ${config.animation ? 'animation' : ''}`}>
+                </ha-icon>
             </button>
         {/if}
     {/if}
@@ -236,6 +247,7 @@
                         type={card.type}
                         marginTop={config['child-margin-top']}
                         open={open}
+                        animation={config.animation || false}
                         animationState={animationState}
                         clearCardCss={config['clear-children'] || false}
                     />
@@ -300,10 +312,12 @@
         width: 100%;
         text-align: left;
     }
-    .ico {
-        color: var(--arrow-color,var(--primary-text-color,#fff));
+    .ico.animation {
         transition-property: transform;
         transition-duration: 0.35s;
+    }
+    .ico {
+        color: var(--arrow-color,var(--primary-text-color,#fff));
     }
 
     .flipped {
@@ -322,21 +336,5 @@
         background-color: #ffffff25;
         background-size: 100%;
         transition: background 0s;
-    }
-    @keyframes slide-in {
-        0% { transform: translateY(-100%); }
-        100% { transform: translateY(0%); }
-    }
-    @-webkit-keyframes slide-in {
-        0% { -webkit-transform: translateY(-100%); }
-        100% { -webkit-transform: translateY(0%); }
-    }
-    @keyframes slide-out {
-        0% { transform: translateY(0%); }
-        100% { transform: translateY(-100%); }
-    }
-    @-webkit-keyframes slide-out {
-        0% { -webkit-transform: translateY(0%); }
-        100% { -webkit-transform: translateY(-100%); }
     }
 </style>

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -42,4 +42,5 @@ export interface ExpanderConfig {
     'icon-rotate-degree'?: string;
     'show-button-users'?: { type: string }[];
     'start-expanded-users'?: { type: string }[];
+    animation?: boolean;
 }


### PR DESCRIPTION
Closes #657 

NOTE: For the improved animation a resize observer is used to get the card height. For this to work hui-card needs to be not the default `display: inline`. When animation is used, hui-card is given `display: flex` with `flex-direction: column`. There is a chance this will break something not tested (all 2.8 issues tested) but I think it is very minimal given that the use of hui-card fixes issues and has only bee out a day.