### PR TITLE
fix: Show preview of cards. Title card always in preview, expander cards when expander open in preview.

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -23,6 +23,7 @@ limitations under the License.
         type = 'div',
         config,
         hass,
+        preview,
         marginTop ='0px',
         open,
         animation = true,
@@ -32,6 +33,7 @@ limitations under the License.
         type?: string;
         config: LovelaceCardConfig;
         hass: HomeAssistant | undefined;
+        preview: boolean;
         marginTop?: string;
         open: boolean;
         animation: boolean;
@@ -50,6 +52,11 @@ limitations under the License.
     });
     $effect(() => {
         if (container) {
+            container.preview = preview;
+        }
+    });
+    $effect(() => {
+        if (container) {
             container.hidden = !open;
             cardConfig.disabled = !open;
             // eslint-disable-next-line no-underscore-dangle
@@ -60,6 +67,7 @@ limitations under the License.
     onMount(async () => {
         const el: HuiCard = document.createElement('hui-card') as HuiCard;
         el.hass = hass;
+        el.preview = preview;
         el.hidden = !open;
         cardConfig.disabled = !open;
         el.config = cardConfig;

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -45,8 +45,9 @@
 
     const {
         hass,
+        preview,
         config = defaults
-    }: {hass: HomeAssistant; config: ExpanderConfig} = $props();
+    }: {hass: HomeAssistant; preview: boolean; config: ExpanderConfig} = $props();
 
     let touchPreventClick = $state(false);
     let open = $state(false);
@@ -197,6 +198,7 @@
                 onclick={config['title-card-clickable'] ? buttonClickDiv : null}
                 role={config['title-card-clickable'] ? 'button' : undefined}>
                 <Card hass={hass}
+                    preview={preview}
                     config={config['title-card']}
                     type={config['title-card'].type}
                     animation={false}
@@ -243,6 +245,7 @@
             >
                 {#each config.cards as card (card)}
                     <Card hass={hass}
+                        preview={open && preview}
                         config={card}
                         type={card.type}
                         marginTop={config['child-margin-top']}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface LovelaceCardConfig {
 export interface LovelaceCard extends HTMLElement {
     hass?: HomeAssistant;
     isPanel?: boolean;
-    editMode?: boolean;
+    preview?: boolean;
     getCardSize(): number | Promise<number>;
     config?: LovelaceCardConfig;
 }


### PR DESCRIPTION
Closes #675 

Example (hightlighting apex charts issue )

Preview:

<img width="346" height="590" alt="Screenshot 2025-10-09 at 12 04 48 pm" src="https://github.com/user-attachments/assets/36dd6098-2d14-4ac0-b098-1a3da30b36d3" />

Non-preview

<img width="346" height="141" alt="Screenshot 2025-10-09 at 12 05 03 pm" src="https://github.com/user-attachments/assets/32e478a1-c910-49da-a9ca-b00aaf1bac8b" />
