### PR TITLE
fix: Conifguration error when using custom-card-features custom element

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -42,7 +42,7 @@ limitations under the License.
     let container = $state<HuiCard>();
     let loading = $state(true);
     let cardHeight = $state(0);
-    const cardConfig = $state<LovelaceCardConfig>(JSON.parse(JSON.stringify(config)));
+    const cardConfig: LovelaceCardConfig = JSON.parse(JSON.stringify(config));
     $effect(() => {
         if (container) {
             container.hass = hass;


### PR DESCRIPTION
See https://community.home-assistant.io/t/expander-accordion-collapsible-card/738817/76

User may submit an issue. If so I will update that this PR closes the issue.

For context see https://github.com/sveltejs/svelte/issues/13562

As cardConfig is not used in any Svelte object it does not need to be a state in card. I have tested this and open/close works fine.