### PR TITLE
feat: Gui editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ Yaml Options:
 | type                      | string   | **Required**  | `custom:expander-card` | Type of the card.                                     |
 | title                     | string   | Empty         | *                      | Title (Not displayed if using Title-Card)             |
 | icon                      | string   | mdi:chevron-down         | mdi icon shortcut                      | Icon in button           |
-| arrow-color               | string   | primary-text-color,#fff | css-color    | Color of ico expand button                     |
-| icon-rotate-degree        | string   | _180deg_      | css-rotate             | Changing the degrees of the button icon when clicked  |
-| header-color              | string   | primary-text-color,#fff  | css-color   | Color of expand button                     |
-| button-background         | string   | _transparent_ | css-color              | Background color of expand button                     |
 | expanded                  | boolean  | _false_       | true\|false            | Start expanded                                        |
 | animation                 | boolean   | _true_       | true\|false            | Should the opening/closing of expander be animated? |
 | min-width-expanded        | number   | 0             | number                 | Min screen width (px) to be expanded on start (use with start expanded above)                                     |
 | max-width-expanded        | number   | 0             | number            | Max screen width (px) to be expanded on start (use with start expanded above)                                        |
 | storage-id                | string   | **optional**  | *                      | Save last expander state in local browser storage     |
 | expander-card-id          | string    | **optional** | *                      | An id to use with [Set state via action](#set-state-via-action)        |
+| arrow-color               | string   | primary-text-color,#fff | css-color    | Color of ico expand button                     |
+| icon-rotate-degree        | string   | _180deg_      | css-rotate             | Changing the degrees of the button icon when clicked  |
+| header-color              | string   | primary-text-color,#fff  | css-color   | Color of expand button                     |
+| button-background         | string   | _transparent_ | css-color              | Background color of expand button                     |
 | expander-card-background  | string   | ha-card-background, card-background-color,#fff | css-color              | Expander Card Background |
 | expander-card-background-expanded    | string   |  Empty    | css-color              | Expander Card Background when card is opened/expanded|
 | expander-card-display     | string   | block         | css-display            | Layout/Display of the card                            |

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Yaml Options:
 | title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                 |
 | overlay-margin            | string   | _0.0em_       | css-size               | Margin from top right of expander button (if overlay) |
 | title-card-padding        | string   | _0px_         | css-size               | padding of title-card                                 |
-| show-button-users         | object[] | **optional**  | *                      | Choose the persons/users that button is visible to them. GUI will save person ids. Adding usernames supported only in YAML. |
-| start-expanded-users      | object[] | **optional**  | *                      | Choose the persons/users that card will be start expanded for them. GUI will save person ids. Adding usernames supported only in YAML. |
+| show-button-users         | object[] | **optional**  | *                      | Choose the persons/users that button is visible to them. |
+| start-expanded-users      | object[] | **optional**  | *                      | Choose the persons/users that card will be start expanded for them. |
 | cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                     |
 
 ### Deprecation Warning

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Clear Background (default theme):
 
 ## Options
 
-Graphical config Editor is currently not  supported. Contribution welcome!
+All options are available for editing in Graphical config editor. Title card config is in YAML at this time.
 
 Yaml Options:
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,11 @@
 [![PayPal.Me][paypal-me-badge]][paypal-me-url]
 [![BuyMeCoffee][buy-me-a-coffee-shield]][buy-me-a-coffee-url]
 
-
 Expander/Collapsible card for HomeAssistant  
 
 ## Introduction
 
 First a few words to start with. A big thank you goes to @Alia5 (https://github.com/Alia5/lovelace-expander-card), who initially launched the card. I forked this card for my own HomeAssistant to make a few improvements. I give no guarantee for the functionality and no promise of lifelong maintenance, as I do the whole thing in my free time. Of course, I am happy about every contribution and PR
-
 
 ## Demo
 
@@ -32,7 +30,6 @@ You can even nest expanders!
 
 ---
 
-
 Clear Background (default theme):  
 
 ![Sample clear router](examples/clear_router.png)
@@ -41,7 +38,6 @@ Clear Background (default theme):
 
 Graphical config Editor is currently not  supported. Contribution welcome!
 
-
 Yaml Options:
 
 | Name                      | Type     | Default       | Supported options      | Description                                           |
@@ -49,38 +45,38 @@ Yaml Options:
 | type                      | string   | **Required**  | `custom:expander-card` | Type of the card.                                     |
 | title                     | string   | Empty         | *                      | Title (Not displayed if using Title-Card)             |
 | icon                      | string   | mdi:chevron-down         | mdi icon shortcut                      | Icon in button           |
-| clear                     | boolean  | _false_       | true\|false            | Remove Background, border                                   |
-| clear-children            | boolean  | _false_       | true\|false            | Remove Background, border from childs                                   |
-| expanded                  | boolean  | _false_       | true\|false            | Start expanded                                        |
-| min-width-expanded        | number   | 0             | number                 | Min screen width (px) to be expanded on start (use with start expanded above)                                     |
-| max-width-expanded        | number   | 0             | number            | Max screen width (px) to be expanded on start (use with start expanded above)                                        |
-| expander-card-background  | string   | ha-card-background, card-background-color,#fff | css-color              | Expander Card Background |
-| expander-card-background-expanded    | string   |  Empty    | css-color              | Expander Card Background when card is opened/expanded|
+| arrow-color               | string   | primary-text-color,#fff | css-color    | Color of ico expand button                     |
+| icon-rotate-degree        | string   | _180deg_      | css-rotate             | Changing the degrees of the button icon when clicked  |
 | header-color              | string   | primary-text-color,#fff  | css-color   | Color of expand button                     |
 | button-background         | string   | _transparent_ | css-color              | Background color of expand button                     |
-| arrow-color               | string   | primary-text-color,#fff | css-color    | Color of ico expand button                     |
+| expanded                  | boolean  | _false_       | true\|false            | Start expanded                                        |
+| animation                 | boolean   | _true_       | true\|false            | Should the opening/closing of expander be animated? |
+| min-width-expanded        | number   | 0             | number                 | Min screen width (px) to be expanded on start (use with start expanded above)                                     |
+| max-width-expanded        | number   | 0             | number            | Max screen width (px) to be expanded on start (use with start expanded above)                                        |
+| storage-id                | string   | **optional**  | *                      | Save last expander state in local browser storage     |
+| expander-card-id          | string    | **optional** | *                      | An id to use with [Set state via action](#set-state-via-action)        |
+| expander-card-background  | string   | ha-card-background, card-background-color,#fff | css-color              | Expander Card Background |
+| expander-card-background-expanded    | string   |  Empty    | css-color              | Expander Card Background when card is opened/expanded|
+| expander-card-display     | string   | block         | css-display            | Layout/Display of the card                            |
+| clear                     | boolean  | _false_       | true\|false            | Remove Background, border                                   |
 | gap                       | string   | _0.0em_       | css-size               | gap between cards when expander closed                |
-| expanded-gap              | string   | _0.6em_       | css-size               | gap between child cards when expander open            |
 | padding                   | string   | _1em_         | css-size               | padding of all card content                           |
+| expanded-gap              | string   | _0.6em_       | css-size               | gap between child cards when expander open            |
 | child-padding             | string   | _0.0em_       | css-size               | padding of child cards                                |
 | child-margin-top          | string   | _0.0em_       | css-size               | Margin top of child cards                             |
+| clear-children            | boolean  | _false_       | true\|false            | Remove Background, border from childs                                   |
 | title-card                | object   | **optional**  | LovelaceCardConfig     | Replace Title with card                               |
-| title-card-padding        | string   | _0px_         | css-size               | padding of title-card                                 |
-| title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                 |
 | title-card-clickable      | boolean  | _false_       | true\|false            | Should the complete diff clickable?                   |
+| title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card                 |
 | overlay-margin            | string   | _0.0em_       | css-size               | Margin from top right of expander button (if overlay) |
-| storage-id                | string   | **optional**  | *                      | Save last expander state in local browser storage     |
+| title-card-padding        | string   | _0px_         | css-size               | padding of title-card                                 |
+| show-button-users         | object[] | **optional**  | *                      | Choose the persons/users that button is visible to them. GUI will save person ids. Adding usernames supported only in YAML. |
+| start-expanded-users      | object[] | **optional**  | *                      | Choose the persons/users that card will be start expanded for them. GUI will save person ids. Adding usernames supported only in YAML. |
 | cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                     |
-| expander-card-display     | string   | block         | css-display            | Layout/Display of the card                            |
-| icon-rotate-degree        | string   | _180deg_      | css-rotate             | Changing the degrees of the button icon when clicked  |
-| show-button-users         | object[] | **optional**  | *                      | Choose the users that button is visible to them       |
-| start-expanded-users      | object[] | **optional**  | *                      | Choose the users that card will be start expanded for them|
-| animation                 | boolean   | _true_       | true\|false            | Should the opening/closing of expander be animated? |
-| expander-card-id          | string    | **optional** | *                      | An id to use with [Set state via action](#set-state-via-action)        |
-
 
 ### Deprecation Warning
-* `storgage-id` was introduced in v2.5.0 and is deprecated in favor of `storage-id`. The older `storgage-id` will be removed in a future release.
+
+* `storage-id` was introduced in v2.5.0 and is deprecated in favor of `storgage-id`. The older `storgage-id` will be removed in a future release.
 
 ## Examples
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,6 @@
-sonar.typescript.tsconfigPaths=tsconfig.json
-sonar.javascript.ecmaVersion=2019
+
+sonar.issue.ignore.multicriteria=ts1,ts2
+sonar.issue.ignore.multicriteria.ts1.ruleKey=typescript:S7764
+sonar.issue.ignore.multicriteria.ts1.resourceKey=**/*.ts
+sonar.issue.ignore.multicriteria.ts2.ruleKey=typescript:S7781
+sonar.issue.ignore.multicriteria.ts2.resourceKey=**/*.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-
-sonar.issue.ignore.multicriteria=ts1,ts2
-sonar.issue.ignore.multicriteria.ts1.ruleKey=typescript:S7764
-sonar.issue.ignore.multicriteria.ts1.resourceKey=**/*.ts
-sonar.issue.ignore.multicriteria.ts2.ruleKey=typescript:S7781
-sonar.issue.ignore.multicriteria.ts2.resourceKey=**/*.ts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.typescript.tsconfigPaths=tsconfig.json
+sonar.javascript.ecmaVersion=2019

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -21,6 +21,7 @@
             'icon-rotate-degree': '180deg',
             'animation': true
         };
+        import { loadExpanderCardEditor } from './ExpanderCardEditor';
 </script>
 
 <!-- eslint-disable-next-line svelte/valid-compile -->
@@ -29,6 +30,19 @@
     extend: (customElementConstructor) => class extends customElementConstructor {
         // re-declare props used in customClass.
         public config!: ExpanderConfig;
+
+        public static async getConfigElement() {
+            await loadExpanderCardEditor();
+            return document.createElement('expander-card-editor');
+        }
+
+        public static getStubConfig() {
+            return {
+                type: 'custom:expander-card',
+                title: 'Expander Card',
+                cards: []
+            };
+        }
 
         public setConfig(conf = {}) {
             this.config = { ...defaults, ...conf };
@@ -50,14 +64,63 @@
     }: {hass: HomeAssistant; preview: boolean; config: ExpanderConfig} = $props();
 
     let touchPreventClick = $state(false);
-    let open = $state(false);
+    let open = $state(preview ? true : false);
+    let previewState = $state(preview ? true : false);
+    let showButtonUsers = $state(true);
     let animationState: AnimationState = $state<AnimationState>('idle');
     let animationTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 
     const configId = config['storage-id'] ?? config['storgage-id'];
     const lastStorageOpenStateId = 'expander-open-' + configId;
-    const showButtonUsers = (config['show-button-users'] === undefined || config['show-button-users']?.includes(hass?.user.name));
+    showButtonUsers = preview || (userInList(config['show-button-users']) ?? true);
 
+    $effect(() => {
+        if (preview === previewState) return;
+        previewState = preview;
+        if (previewState) {
+            setOpenState(true);
+            showButtonUsers = true;
+        } else {
+            setDefaultOpenState();
+            showButtonUsers = userInList(config['show-button-users']) ?? true;
+        }
+    });
+
+    function userInList(userList: string[] | undefined): boolean | undefined {
+        if (userList === undefined) {
+            return undefined;
+        }
+        return hass?.user?.name !== undefined && userList.includes(hass?.user?.name);
+    }
+
+    function setDefaultOpenState() {
+        if (userInList(config['start-expanded-users'])) {
+            setOpenState(true);
+        } else if (configId !== undefined) {
+            try {
+                const storageValue = localStorage.getItem(lastStorageOpenStateId);
+                if(storageValue === null){
+                    // first time, set the state from config
+                    if (config.expanded !== undefined) {
+                        setOpenState(config.expanded);
+                    }
+                }
+                else {
+                    // last state is stored in local storage
+                    open = storageValue ? storageValue === 'true' : open;
+                }
+            } catch (e) {
+                console.error(e);
+            }
+        }else{
+            // first time, set the state from config
+            if (config.expanded !== undefined) {
+                setOpenState(config.expanded);
+            } else {
+                setOpenState(false);
+            }
+        }
+    }
 
     function toggleOpen(openState?: boolean) {
         if (animationTimeout) {
@@ -128,29 +191,10 @@
             config.expanded = offsetWidth <= maxWidthExpanded;
         }
 
-        if (config['start-expanded-users']?.includes(hass?.user.name)) {
+        if (preview) {
             setOpenState(true);
-        } else if (configId !== undefined) {
-            try {
-                const storageValue = localStorage.getItem(lastStorageOpenStateId);
-                if(storageValue === null){
-                    // first time, set the state from config
-                    if (config.expanded !== undefined) {
-                        setOpenState(config.expanded);
-                    }
-                }
-                else {
-                    // last state is stored in local storage
-                    open = storageValue ? storageValue === 'true' : open;
-                }
-            } catch (e) {
-                console.error(e);
-            }
-        }else{
-            // first time, set the state from config
-            if (config.expanded !== undefined) {
-                setOpenState(config.expanded);
-            }
+        } else {
+            setDefaultOpenState();
         }
 
         document.body.addEventListener('ll-custom', handleDomEvent);
@@ -225,7 +269,7 @@
                     animation={false}
                     open={true}
                     animationState='idle'
-                    clearCardCss={config['clear-children'] || false}
+                    clearCardCss={config['clear-children']!}
                 />
             </div>
             {#if showButtonUsers}
@@ -272,9 +316,9 @@
                         type={card.type}
                         marginTop={config['child-margin-top']}
                         open={open}
-                        animation={config.animation || false}
+                        animation={config.animation!}
                         animationState={animationState}
-                        clearCardCss={config['clear-children'] || false}
+                        clearCardCss={config['clear-children']!}
                     />
                 {/each}
             </div>

--- a/src/ExpanderCardEditor.ts
+++ b/src/ExpanderCardEditor.ts
@@ -4,13 +4,15 @@
 import { ExpanderCardEditorNulls, ExpanderCardEditorSchema } from './editortype';
 import { HomeAssistantUser } from './types';
 
-let helpers = (window as any).cardHelpers;
+const wdw = window; // NOSONAR es2019
+
+let helpers = (wdw as any).cardHelpers;
 const helperPromise = new Promise<void>((resolve) => {
     if (helpers) resolve();
-    if ((window as any).loadCardHelpers) {
-        (window as any).loadCardHelpers().then((loadedHelpers: any) => {
+    if ((wdw as any).loadCardHelpers) {
+        (wdw as any).loadCardHelpers().then((loadedHelpers: any) => {
             helpers = loadedHelpers;
-            (window as any).cardHelpers = helpers;
+            (wdw as any).cardHelpers = helpers;
             resolve();
         });
     }
@@ -52,9 +54,9 @@ const loader = async (): Promise<any> => {
             const schema = ExpanderCardEditorSchema;
             const schemaJSON = JSON.stringify(schema);
             const usersEscaped = this._users
-                .map((u: string) => u.replace(/\\/g, '\\\\').replace(/"/g, '\\"'))
+                .map((u: string) => u.replace(/\\/g, '\\\\').replace(/"/g, '\\"')) // NOSONAR es2019
                 .join('","');
-            const populatedSchemaJSON = schemaJSON.replace(/\[\[users\]\]/g, usersEscaped);
+            const populatedSchemaJSON = schemaJSON.replace(/\[\[users\]\]/g, usersEscaped); // NOSONAR es2019
             const populatedSchema = JSON.parse(populatedSchemaJSON);
             return populatedSchema;
         }
@@ -70,18 +72,18 @@ const loader = async (): Promise<any> => {
         // override _valueChanged to remove null values from config before storing and firing event
         public _valueChanged = (ev: CustomEvent): void => {
             const config = ev.detail.value;
-            Object.entries(ExpanderCardEditorNulls).forEach(([key, value]) => {
+            const entries = Object.entries(ExpanderCardEditorNulls);
+            for (const [key, value] of entries) {
                 if (typeof value === 'object' && Array.isArray(value) && Array.isArray(config[key])) {
                     if (JSON.stringify(config[key]) === JSON.stringify(value)) {
                         delete config[key];
                     }
-                    return;
+                    continue;
                 }
                 if (config[key] === value) {
                     delete config[key];
-                    return;
                 }
-            });
+            }
             this._config = config;
             this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config } }));
         };
@@ -91,7 +93,7 @@ const loader = async (): Promise<any> => {
 export const loadExpanderCardEditor = (async () => {
     // Wait for scoped customElements registry to be set up
     while (customElements.get('home-assistant') === undefined)
-        await new Promise((resolve) => window.setTimeout(resolve, 100));
+        await new Promise((resolve) => wdw.setTimeout(resolve, 100));
 
     if (!customElements.get('expander-card-editor')) {
         const expanderCardEditor = await loader();

--- a/src/ExpanderCardEditor.ts
+++ b/src/ExpanderCardEditor.ts
@@ -1,0 +1,100 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { ExpanderCardEditorNulls, ExpanderCardEditorSchema } from './editortype';
+import { HomeAssistantUser } from './types';
+
+let helpers = (window as any).cardHelpers;
+const helperPromise = new Promise<void>((resolve) => {
+    if (helpers) resolve();
+    if ((window as any).loadCardHelpers) {
+        (window as any).loadCardHelpers().then((loadedHelpers: any) => {
+            helpers = loadedHelpers;
+            (window as any).cardHelpers = helpers;
+            resolve();
+        });
+    }
+});
+
+async function fetchUsers(): Promise<void> {
+    const el = document.querySelector('home-assistant');
+    const hass = (el as any)?.hass;
+    if (!hass) return;
+    const users = await hass.callWS({ type: 'config/auth/list' });
+    return users
+        .filter((user: HomeAssistantUser) => !user.system_generated)
+        .map((user: HomeAssistantUser) => user.name);
+}
+
+const loader = async (): Promise<any> => {
+    // create a temporary vertical-stack card to inherit from
+    const verticalStackCard = await helperPromise.then(() =>
+        helpers.createCardElement({ type: 'vertical-stack', cards: [] }));
+    // get its editor class
+    const verticalStackEditor = await verticalStackCard.constructor.getConfigElement();
+    // fetch users
+    const users = await fetchUsers();
+    // return a new class that extends the vertical-stack editor
+    return class ExpanderCardEditor extends verticalStackEditor.constructor {
+        public constructor() {
+            super();
+            this._users = users;
+        }
+
+        // override setConfig to store config only and not assert stack editor config
+        // we also upgrade any old config here if needed
+        public setConfig(config: any): void {
+            this._config = config;
+        }
+
+        // define _schema getter to return our own schema
+        public get _schema(): any {
+            const schema = ExpanderCardEditorSchema;
+            const schemaJSON = JSON.stringify(schema);
+            const usersEscaped = this._users
+                .map((u: string) => u.replace(/\\/g, '\\\\').replace(/"/g, '\\"'))
+                .join('","');
+            const populatedSchemaJSON = schemaJSON.replace(/\[\[users\]\]/g, usersEscaped);
+            const populatedSchema = JSON.parse(populatedSchemaJSON);
+            return populatedSchema;
+        }
+
+        // _schema setter does nothing as we want to use our own schema
+        public set _schema(_) {
+            // do nothing
+        }
+
+        // override _computeLabelCallback to show label or name
+        public _computeLabelCallback = (item: any): string => item.label ?? item.name ?? '';
+
+        // override _valueChanged to remove null values from config before storing and firing event
+        public _valueChanged = (ev: CustomEvent): void => {
+            const config = ev.detail.value;
+            Object.entries(ExpanderCardEditorNulls).forEach(([key, value]) => {
+                if (typeof value === 'object' && Array.isArray(value) && Array.isArray(config[key])) {
+                    if (JSON.stringify(config[key]) === JSON.stringify(value)) {
+                        delete config[key];
+                    }
+                    return;
+                }
+                if (config[key] === value) {
+                    delete config[key];
+                    return;
+                }
+            });
+            this._config = config;
+            this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config } }));
+        };
+    };
+};
+
+export const loadExpanderCardEditor = (async () => {
+    // Wait for scoped customElements registry to be set up
+    while (customElements.get('home-assistant') === undefined)
+        await new Promise((resolve) => window.setTimeout(resolve, 100));
+
+    if (!customElements.get('expander-card-editor')) {
+        const expanderCardEditor = await loader();
+        customElements.define('expander-card-editor', expanderCardEditor);
+    }
+});

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -16,10 +16,10 @@ export interface ExpanderConfig {
     clear?: boolean;
     'clear-children'?: boolean;
     cards?: { type: string }[];
-    gap: string;
-    'expanded-gap': string;
-    padding: string;
-    title: string;
+    gap?: string;
+    'expanded-gap'?: string;
+    padding?: string;
+    title?: string;
     'title-card'?: LovelaceCardConfig;
     'title-card-padding'?: string;
     'title-card-button-overlay'?: false;
@@ -31,7 +31,7 @@ export interface ExpanderConfig {
     'expander-card-background'?: string;
     'expander-card-background-expanded'?: string;
     'header-color'?: string;
-    'button-background': string;
+    'button-background'?: string;
     'arrow-color'?: string;
     'expander-card-display'?: string;
     'min-width-expanded'?: number;
@@ -40,8 +40,8 @@ export interface ExpanderConfig {
     'storgage-id'?: string;  // Deprecated as of 2.6.5
     'storage-id'?: string;
     'icon-rotate-degree'?: string;
-    'show-button-users'?: { type: string }[];
-    'start-expanded-users'?: { type: string }[];
+    'show-button-users'?: string[];
+    'start-expanded-users'?: string[];
     animation?: boolean;
     'expander-card-id'?: string;
 }

--- a/src/editortype.ts
+++ b/src/editortype.ts
@@ -25,6 +25,15 @@ export const ExpanderCardEditorNulls: ExpanderConfig = {
     'title-card-padding': ''
 };
 
+const iconSelector = { icon: {} };
+const textSelector = { text: {} };
+const booleanSelector = { boolean: {} };
+const numberPxSelector = {
+    number: {
+        unit_of_measurement: 'px'
+    }
+};
+
 // See https://www.home-assistant.io/docs/blueprint/selectors
 export const ExpanderCardEditorSchema = [
     {
@@ -35,12 +44,12 @@ export const ExpanderCardEditorSchema = [
             {
                 name: 'title',
                 label: 'Title',
-                selector: { text: {} }
+                selector: textSelector
             },
             {
                 name: 'icon',
                 label: 'Icon',
-                selector: { icon: {} }
+                selector: iconSelector
             },
             {
                 type: 'expandable',
@@ -53,40 +62,32 @@ export const ExpanderCardEditorSchema = [
                             {
                                 name: 'expanded',
                                 label: 'Start expanded',
-                                selector: { boolean: {} }
+                                selector: booleanSelector
                             },
                             {
                                 name: 'animation',
                                 label: 'Enable animation',
-                                selector: { boolean: {} }
+                                selector: booleanSelector
                             },
                             {
                                 name: 'min-width-expanded',
                                 label: 'Min width expanded',
-                                selector: {
-                                    number: {
-                                        unit_of_measurement: 'px'
-                                    }
-                                }
+                                selector: numberPxSelector
                             },
                             {
                                 name: 'max-width-expanded',
                                 label: 'Max width expanded',
-                                selector: {
-                                    number: {
-                                        unit_of_measurement: 'px'
-                                    }
-                                }
+                                selector: numberPxSelector
                             },
                             {
                                 name: 'storage-id',
                                 label: 'Storage ID',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'expander-card-id',
                                 label: 'Expander card ID',
-                                selector: { text: {} }
+                                selector: textSelector
                             }
                         ]
                     }
@@ -103,52 +104,52 @@ export const ExpanderCardEditorSchema = [
                             {
                                 name: 'arrow-color',
                                 label: 'Icon color',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'icon-rotate-degree',
                                 label: 'Icon rotate degree',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'header-color',
                                 label: 'Header color',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'button-background',
                                 label: 'Button background color',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'expander-card-background',
                                 label: 'Background',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'expander-card-background-expanded',
                                 label: 'Background when expanded',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'expander-card-display',
                                 label: 'Expander card display',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'clear',
                                 label: 'Clear border and background',
-                                selector: { boolean: {} }
+                                selector: booleanSelector
                             },
                             {
                                 name: 'gap',
                                 label: 'Gap',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'padding',
                                 label: 'Padding',
-                                selector: { text: {} }
+                                selector: textSelector
                             }
                         ]
                     }
@@ -165,22 +166,22 @@ export const ExpanderCardEditorSchema = [
                             {
                                 name: 'expanded-gap',
                                 label: 'Card gap',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'child-padding',
                                 label: 'Card padding',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'child-margin-top',
                                 label: 'Card margin top',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'clear-children',
                                 label: 'Clear card border and background',
-                                selector: { boolean: {} }
+                                selector: booleanSelector
                             }
                         ]
                     }
@@ -206,22 +207,22 @@ export const ExpanderCardEditorSchema = [
                             {
                                 name: 'title-card-clickable',
                                 label: 'Make title card clickable to expand/collapse',
-                                selector: { boolean: {} }
+                                selector: booleanSelector
                             },
                             {
                                 name: 'title-card-button-overlay',
                                 label: 'Overlay expand button on title card',
-                                selector: { boolean: {} }
+                                selector: booleanSelector
                             },
                             {
                                 name: 'overlay-margin',
                                 label: 'Overlay margin',
-                                selector: { text: {} }
+                                selector: textSelector
                             },
                             {
                                 name: 'title-card-padding',
                                 label: 'Title card padding',
-                                selector: { text: {} }
+                                selector: textSelector
                             }
                         ]
                     }

--- a/src/editortype.ts
+++ b/src/editortype.ts
@@ -38,46 +38,9 @@ export const ExpanderCardEditorSchema = [
                 selector: { text: {} }
             },
             {
-                type: 'expandable',
-                label: 'Expander header',
-                icon: 'mdi:card-outline',
-                schema: [
-                    {
-                        type: 'grid',
-                        schema: [
-                            {
-                                name: 'icon',
-                                label: 'Icon',
-                                selector: { icon: {} }
-                            },
-                            {
-                                name: 'arrow-color',
-                                label: 'Icon color',
-                                selector: { text: {} }
-                            },
-                            {
-                                name: 'icon-rotate-degree',
-                                label: 'Icon rotate degree',
-                                selector: { text: {} }
-                            }
-                        ]
-                    },
-                    {
-                        type: 'grid',
-                        schema: [
-                            {
-                                name: 'header-color',
-                                label: 'Header color',
-                                selector: { text: {} }
-                            },
-                            {
-                                name: 'button-background',
-                                label: 'Button background color',
-                                selector: { text: {} }
-                            }
-                        ]
-                    }
-                ]
+                name: 'icon',
+                label: 'Icon',
+                selector: { icon: {} }
             },
             {
                 type: 'expandable',
@@ -137,6 +100,26 @@ export const ExpanderCardEditorSchema = [
                     {
                         type: 'grid',
                         schema: [
+                            {
+                                name: 'arrow-color',
+                                label: 'Icon color',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'icon-rotate-degree',
+                                label: 'Icon rotate degree',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'header-color',
+                                label: 'Header color',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'button-background',
+                                label: 'Button background color',
+                                selector: { text: {} }
+                            },
                             {
                                 name: 'expander-card-background',
                                 label: 'Background',
@@ -258,6 +241,7 @@ export const ExpanderCardEditorSchema = [
                                 selector: {
                                     select: {
                                         multiple: true,
+                                        mode: 'dropdown',
                                         custom: true, // to allow for unknown users
                                         options: ['[[users]]'] // to be populated dynamically
                                     }
@@ -269,6 +253,7 @@ export const ExpanderCardEditorSchema = [
                                 selector: {
                                     select: {
                                         multiple: true,
+                                        mode: 'dropdown',
                                         custom: true, // to allow for unknown users
                                         options: ['[[users]]'] // to be populated dynamically
                                     }

--- a/src/editortype.ts
+++ b/src/editortype.ts
@@ -1,0 +1,283 @@
+/* eslint-disable quote-props */
+import { ExpanderConfig } from './configtype';
+
+export const ExpanderCardEditorNulls: ExpanderConfig = {
+    icon: '',
+    'arrow-color': '',
+    'icon-rotate-degree': '',
+    'header-color': '',
+    'button-background': '',
+    'min-width-expanded': 0,
+    'max-width-expanded': 0,
+    'storage-id': '',
+    'expander-card-id': '',
+    'show-button-users': [],
+    'start-expanded-users': [],
+    'expander-card-background': '',
+    'expander-card-background-expanded': '',
+    'expander-card-display': '',
+    gap: '',
+    padding: '',
+    'expanded-gap': '',
+    'child-padding': '',
+    'child-margin-top': '',
+    'overlay-margin': '',
+    'title-card-padding': ''
+};
+
+// See https://www.home-assistant.io/docs/blueprint/selectors
+export const ExpanderCardEditorSchema = [
+    {
+        type: 'expandable',
+        label: 'Expander Card Settings',
+        icon: 'mdi:arrow-down-bold-box-outline',
+        schema: [
+            {
+                name: 'title',
+                label: 'Title',
+                selector: { text: {} }
+            },
+            {
+                type: 'expandable',
+                label: 'Expander header',
+                icon: 'mdi:card-outline',
+                schema: [
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'icon',
+                                label: 'Icon',
+                                selector: { icon: {} }
+                            },
+                            {
+                                name: 'arrow-color',
+                                label: 'Icon color',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'icon-rotate-degree',
+                                label: 'Icon rotate degree',
+                                selector: { text: {} }
+                            }
+                        ]
+                    },
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'header-color',
+                                label: 'Header color',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'button-background',
+                                label: 'Button background color',
+                                selector: { text: {} }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                type: 'expandable',
+                label: 'Expander control',
+                icon: 'mdi:cog-outline',
+                schema: [
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'expanded',
+                                label: 'Start expanded',
+                                selector: { boolean: {} }
+                            },
+                            {
+                                name: 'animation',
+                                label: 'Enable animation',
+                                selector: { boolean: {} }
+                            },
+                            {
+                                name: 'min-width-expanded',
+                                label: 'Min width expanded',
+                                selector: {
+                                    number: {
+                                        unit_of_measurement: 'px'
+                                    }
+                                }
+                            },
+                            {
+                                name: 'max-width-expanded',
+                                label: 'Max width expanded',
+                                selector: {
+                                    number: {
+                                        unit_of_measurement: 'px'
+                                    }
+                                }
+                            },
+                            {
+                                name: 'storage-id',
+                                label: 'Storage ID',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'expander-card-id',
+                                label: 'Expander card ID',
+                                selector: { text: {} }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                type: 'expandable',
+                label: 'Expander styling',
+                icon: 'mdi:palette-swatch',
+                schema: [
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'expander-card-background',
+                                label: 'Background',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'expander-card-background-expanded',
+                                label: 'Background when expanded',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'expander-card-display',
+                                label: 'Expander card display',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'clear',
+                                label: 'Clear border and background',
+                                selector: { boolean: {} }
+                            },
+                            {
+                                name: 'gap',
+                                label: 'Gap',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'padding',
+                                label: 'Padding',
+                                selector: { text: {} }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                type: 'expandable',
+                label: 'Card styling',
+                icon: 'mdi:palette-swatch-outline',
+                schema: [
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'expanded-gap',
+                                label: 'Card gap',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'child-padding',
+                                label: 'Card padding',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'child-margin-top',
+                                label: 'Card margin top',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'clear-children',
+                                label: 'Clear card border and background',
+                                selector: { boolean: {} }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                type: 'expandable',
+                label: 'Title card',
+                icon: 'mdi:subtitles-outline',
+                schema: [
+                    {
+                        label: 'Use YAML to specify a title card to replace the expander title',
+                        type: 'constant'
+                    },
+                    {
+                        name: 'title-card',
+                        label: '',
+                        selector: { object: {} }
+                    },
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'title-card-clickable',
+                                label: 'Make title card clickable to expand/collapse',
+                                selector: { boolean: {} }
+                            },
+                            {
+                                name: 'title-card-button-overlay',
+                                label: 'Overlay expand button on title card',
+                                selector: { boolean: {} }
+                            },
+                            {
+                                name: 'overlay-margin',
+                                label: 'Overlay margin',
+                                selector: { text: {} }
+                            },
+                            {
+                                name: 'title-card-padding',
+                                label: 'Title card padding',
+                                selector: { text: {} }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                type: 'expandable',
+                label: 'User settings',
+                icon: 'mdi:account-multiple-outline',
+                schema: [
+                    {
+                        type: 'grid',
+                        schema: [
+                            {
+                                name: 'show-button-users',
+                                label: 'Show button users',
+                                selector: {
+                                    select: {
+                                        multiple: true,
+                                        custom: true, // to allow for unknown users
+                                        options: ['[[users]]'] // to be populated dynamically
+                                    }
+                                }
+                            },
+                            {
+                                name: 'start-expanded-users',
+                                label: 'Start expanded users',
+                                selector: {
+                                    select: {
+                                        multiple: true,
+                                        custom: true, // to allow for unknown users
+                                        options: ['[[users]]'] // to be populated dynamically
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+];

--- a/src/editortype.ts
+++ b/src/editortype.ts
@@ -28,11 +28,47 @@ export const ExpanderCardEditorNulls: ExpanderConfig = {
 const iconSelector = { icon: {} };
 const textSelector = { text: {} };
 const booleanSelector = { boolean: {} };
-const numberPxSelector = {
+const objectSelector = { object: {} };
+const numberSelector = (unit_of_measurement: string) => ({
     number: {
-        unit_of_measurement: 'px'
+        unit_of_measurement
     }
-};
+});
+
+const iconField = (name: string, label: string) => ({
+    name,
+    label,
+    selector: iconSelector
+});
+
+const textField = (name: string, label: string) => ({
+    name,
+    label,
+    selector: textSelector
+});
+
+const booleanField = (name: string, label: string) => ({
+    name,
+    label,
+    selector: booleanSelector
+});
+
+const objectField = (name: string, label: string) => ({
+    name,
+    label,
+    selector: objectSelector
+});
+
+const numberField = (name: string, label: string, unit_of_measurement: string) => ({
+    name,
+    label,
+    selector: numberSelector(unit_of_measurement)
+});
+
+const labelField = (label: string) => ({
+    label,
+    type: 'constant'
+});
 
 // See https://www.home-assistant.io/docs/blueprint/selectors
 export const ExpanderCardEditorSchema = [
@@ -42,14 +78,10 @@ export const ExpanderCardEditorSchema = [
         icon: 'mdi:arrow-down-bold-box-outline',
         schema: [
             {
-                name: 'title',
-                label: 'Title',
-                selector: textSelector
+                ...textField('title', 'Title')
             },
             {
-                name: 'icon',
-                label: 'Icon',
-                selector: iconSelector
+                ...iconField('icon', 'Icon')
             },
             {
                 type: 'expandable',
@@ -60,34 +92,22 @@ export const ExpanderCardEditorSchema = [
                         type: 'grid',
                         schema: [
                             {
-                                name: 'expanded',
-                                label: 'Start expanded',
-                                selector: booleanSelector
+                                ...booleanField('expanded', 'Start expanded')
                             },
                             {
-                                name: 'animation',
-                                label: 'Enable animation',
-                                selector: booleanSelector
+                                ...booleanField('animation', 'Enable animation')
                             },
                             {
-                                name: 'min-width-expanded',
-                                label: 'Min width expanded',
-                                selector: numberPxSelector
+                                ...numberField('min-width-expanded', 'Min width expanded', 'px')
                             },
                             {
-                                name: 'max-width-expanded',
-                                label: 'Max width expanded',
-                                selector: numberPxSelector
+                                ...numberField('max-width-expanded', 'Max width expanded', 'px')
                             },
                             {
-                                name: 'storage-id',
-                                label: 'Storage ID',
-                                selector: textSelector
+                                ...textField('storage-id', 'Storage ID')
                             },
                             {
-                                name: 'expander-card-id',
-                                label: 'Expander card ID',
-                                selector: textSelector
+                                ...textField('expander-card-id', 'Expander card ID')
                             }
                         ]
                     }
@@ -102,54 +122,34 @@ export const ExpanderCardEditorSchema = [
                         type: 'grid',
                         schema: [
                             {
-                                name: 'arrow-color',
-                                label: 'Icon color',
-                                selector: textSelector
+                                ...textField('arrow-color', 'Icon color')
                             },
                             {
-                                name: 'icon-rotate-degree',
-                                label: 'Icon rotate degree',
-                                selector: textSelector
+                                ...textField('icon-rotate-degree', 'Icon rotate degree')
                             },
                             {
-                                name: 'header-color',
-                                label: 'Header color',
-                                selector: textSelector
+                                ...textField('header-color', 'Header color')
                             },
                             {
-                                name: 'button-background',
-                                label: 'Button background color',
-                                selector: textSelector
+                                ...textField('button-background', 'Button background color')
                             },
                             {
-                                name: 'expander-card-background',
-                                label: 'Background',
-                                selector: textSelector
+                                ...textField('expander-card-background', 'Background')
                             },
                             {
-                                name: 'expander-card-background-expanded',
-                                label: 'Background when expanded',
-                                selector: textSelector
+                                ...textField('expander-card-background-expanded', 'Background when expanded')
                             },
                             {
-                                name: 'expander-card-display',
-                                label: 'Expander card display',
-                                selector: textSelector
+                                ...textField('expander-card-display', 'Expander card display')
                             },
                             {
-                                name: 'clear',
-                                label: 'Clear border and background',
-                                selector: booleanSelector
+                                ...booleanField('clear', 'Clear border and background')
                             },
                             {
-                                name: 'gap',
-                                label: 'Gap',
-                                selector: textSelector
+                                ...textField('gap', 'Gap')
                             },
                             {
-                                name: 'padding',
-                                label: 'Padding',
-                                selector: textSelector
+                                ...textField('padding', 'Padding')
                             }
                         ]
                     }
@@ -164,24 +164,16 @@ export const ExpanderCardEditorSchema = [
                         type: 'grid',
                         schema: [
                             {
-                                name: 'expanded-gap',
-                                label: 'Card gap',
-                                selector: textSelector
+                                ...textField('expanded-gap', 'Card gap')
                             },
                             {
-                                name: 'child-padding',
-                                label: 'Card padding',
-                                selector: textSelector
+                                ...textField('child-padding', 'Card padding')
                             },
                             {
-                                name: 'child-margin-top',
-                                label: 'Card margin top',
-                                selector: textSelector
+                                ...textField('child-margin-top', 'Card margin top')
                             },
                             {
-                                name: 'clear-children',
-                                label: 'Clear card border and background',
-                                selector: booleanSelector
+                                ...textField('clear-children', 'Clear card border and background')
                             }
                         ]
                     }
@@ -193,36 +185,25 @@ export const ExpanderCardEditorSchema = [
                 icon: 'mdi:subtitles-outline',
                 schema: [
                     {
-                        label: 'Use YAML to specify a title card to replace the expander title',
-                        type: 'constant'
+                        ...labelField('Use YAML to specify a title card to replace the expander title')
                     },
                     {
-                        name: 'title-card',
-                        label: '',
-                        selector: { object: {} }
+                        ...objectField('title-card', '')
                     },
                     {
                         type: 'grid',
                         schema: [
                             {
-                                name: 'title-card-clickable',
-                                label: 'Make title card clickable to expand/collapse',
-                                selector: booleanSelector
+                                ...booleanField('title-card-clickable', 'Make title card clickable to expand/collapse')
                             },
                             {
-                                name: 'title-card-button-overlay',
-                                label: 'Overlay expand button on title card',
-                                selector: booleanSelector
+                                ...booleanField('title-card-button-overlay', 'Overlay expand button on title card')
                             },
                             {
-                                name: 'overlay-margin',
-                                label: 'Overlay margin',
-                                selector: textSelector
+                                ...textField('overlay-margin', 'Overlay margin')
                             },
                             {
-                                name: 'title-card-padding',
-                                label: 'Title card padding',
-                                selector: textSelector
+                                ...textField('title-card-padding', 'Title card padding')
                             }
                         ]
                     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,14 @@
 export type AnimationState = 'opening' | 'closing' | 'idle';
 
+export interface HomeAssistantUser {
+    id: string;
+    name: string;
+    is_admin: boolean;
+    is_owner: boolean;
+    system_generated: boolean;
+}
 export interface HomeAssistant {
+    user?: HomeAssistantUser;
     [key: string]: unknown;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "module": "esnext",
         "moduleResolution": "bundler",
 		"lib": ["es2019", "dom"],
+		"target": "ES2019"
 	},
     "include": ["src/**/*"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
 		"strict": true,
         "module": "esnext",
         "moduleResolution": "bundler",
-		"lib": ["es2019", "dom"],
-		"target": "ES2019"
+		"lib": ["es2019", "dom"]
 	},
     "include": ["src/**/*"],
 }


### PR DESCRIPTION
Closes #626 

Includes:

- uses standard Frontend GUI editor, superclassed to allow for expander config etc. See comments in ExpanderCardEditor.ts
- ExpanderCardEditor.ts has no display output itself, so is written in typescript, not svelte
- title card is via yaml at this time as there is no form selector for a card. The future plan would be to have a popup dialog with a card chooser/editor.
- used some different nomenclature where it makes better sense
- readme config table updated to match order of config items in GUI editor
- updates preview handling so all expanders are open in preview regardless of settings, and reverts to settings when out of preview/edit mode.
- to note, while Frontend has a CSS color selector, it outputs an RGB array and does not support extended CSS colors like rgba() etc. So I have left as text in config editor

To review:

- config grouping and order
- expander icons
- check config editor nomenclature
- check readme for any updates that would make sense with config editor being available