### PR TITLE
fix: removing of shadow from card when using 'clear' option

### DIFF
--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -312,6 +312,7 @@
         background: none !important;
         background-color: transparent !important;
         border-style: none !important;
+        box-shadow: none !important;
     }
 
     .title-card-header {


### PR DESCRIPTION
When using the 'clear' option, it’s strange to see a shadow on the card. It definitely shouldn’t be there...