### PR TITLE
fix: Use estimated card heights for initial open animation.

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -18,6 +18,7 @@ limitations under the License.
 <script lang="ts">
     import { onMount } from 'svelte';
     import type { AnimationState, HomeAssistant, HuiCard, LovelaceCardConfig } from './types';
+    import { computeCardSize } from './helpers/compute-card-size';
 
     const {
         type = 'div',
@@ -89,6 +90,10 @@ limitations under the License.
         }
 
         if (animation) {
+            // Start with an estimated height.
+            // Update with resize observer once we have the real height.
+            // 56px is the height of one card size unit
+            cardHeight = await computeCardSize(el) * 56;
             const resizeObserver = new ResizeObserver((entries) => {
                 for (const entry of entries) {
                     if (entry.contentBoxSize) {

--- a/src/helpers/compute-card-size.ts
+++ b/src/helpers/compute-card-size.ts
@@ -2,7 +2,7 @@ import { HuiCard } from '../types';
 import { TimeoutError } from './promise-timeout';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const promiseTimeout = (ms: number, promise: Promise<any> | any) => {
+export const promiseTimeout = (ms: number, promise: Promise<any> | any) => { // NOSONAR
     const timeout = new Promise((_resolve, reject) => {
         setTimeout(() => {
             reject(new TimeoutError(ms));

--- a/src/helpers/compute-card-size.ts
+++ b/src/helpers/compute-card-size.ts
@@ -1,0 +1,34 @@
+import { HuiCard } from '../types';
+import { TimeoutError } from './promise-timeout';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const promiseTimeout = (ms: number, promise: Promise<any> | any) => {
+    const timeout = new Promise((_resolve, reject) => {
+        setTimeout(() => {
+            reject(new TimeoutError(ms));
+        }, ms);
+    });
+
+    // Returns a race between our timeout and the passed in promise
+    return Promise.race([promise, timeout]);
+};
+
+export const computeCardSize = (
+    card: HuiCard
+): number | Promise<number> => {
+    if (typeof card.getCardSize === 'function') {
+        try {
+            return promiseTimeout(500, card.getCardSize()).catch(
+                () => 1
+            ) as Promise<number>;
+        } catch {
+            return 1;
+        }
+    }
+    if (customElements.get(card.localName)) {
+        return 1;
+    }
+    return customElements
+        .whenDefined(card.localName)
+        .then(() => computeCardSize(card));
+};

--- a/src/helpers/promise-timeout.ts
+++ b/src/helpers/promise-timeout.ts
@@ -18,7 +18,7 @@ export class TimeoutError extends Error {
     }
 }
 
-export const promiseTimeout = (ms: number, promise: Promise<any> | any) => {
+export const promiseTimeout = (ms: number, promise: Promise<any> | any) => { // NOSONAR
     const timeout = new Promise((_resolve, reject) => {
         setTimeout(() => {
             reject(new TimeoutError(ms));

--- a/src/helpers/promise-timeout.ts
+++ b/src/helpers/promise-timeout.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export class TimeoutError extends Error {
+    public timeout: number;
+
+    // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+    constructor(timeout: number, ...params: undefined[]) {
+        super(...params);
+
+        // Maintains proper stack trace for where our error was thrown (only available on V8)
+        if ((Error as any).captureStackTrace) {
+            (Error as any).captureStackTrace(this, TimeoutError);
+        }
+
+        this.name = 'TimeoutError';
+        // Custom debugging information
+        this.timeout = timeout;
+        this.message = `Timed out in ${timeout} ms.`;
+    }
+}
+
+export const promiseTimeout = (ms: number, promise: Promise<any> | any) => {
+    const timeout = new Promise((_resolve, reject) => {
+        setTimeout(() => {
+            reject(new TimeoutError(ms));
+        }, ms);
+    });
+
+    // Returns a race between our timeout and the passed in promise
+    return Promise.race([promise, timeout]);
+};


### PR DESCRIPTION
Fixes #683 

Uses standard card getCardSize() function to get estimated size before cards are created. This allows the first open animation to be in sync with arrow.

compute-card-size and promise-timeout borrowed from Home Assistant Frontend. Both stable and unchanged for a year.