### PR TITLE
fix: Panel views reload when child cards contain lazy loaded elements

### DIFF
--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -317,7 +317,6 @@
                 <Card hass={hass}
                     preview={preview}
                     config={config['title-card']}
-                    type={config['title-card'].type}
                     animation={false}
                     open={true}
                     animationState='idle'
@@ -376,7 +375,6 @@
                     <Card hass={hass}
                         preview={open && preview}
                         config={card}
-                        type={card.type}
                         marginTop={config['child-margin-top']}
                         open={open}
                         animation={config.animation!}


### PR DESCRIPTION
Fix #781 

Any lazy loaded row would cause a masonry panel to rebuild.

Also updated is redundant code for card which causes container effects when not required.