### PR TITLE
fix: Allow for button overlay height to be styled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Yaml Options:
 | clear-children            | boolean  | _false_       | true\|false            | Remove Background, border from childs                                   |
 | title-card                | object   | **optional**  | LovelaceCardConfig     | Replace Title with card                               |
 | title-card-clickable      | boolean  | _false_       | true\|false            | Should the complete div be clickable?               |
-| title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card. If you set `title-card-clickable: true` the overlay will extend across the expander and capture the click before the title-card. |
+| title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card. If you set `title-card-clickable: true` the overlay will extend across the expander, both horizontally and vertically, and capture the click before the title-card. If you wish to adjust the overlay height you can style `height` on `.header-overlay`. See [Style](#style) |
 | overlay-margin            | string   | _0.0em_       | css-size               | Margin from top right of expander button (if overlay) |
 | title-card-padding        | string   | _0px_         | css-size               | padding of title-card                                 |
 | show-button-users         | object[] | **optional**  | *                      | Choose the persons/users that button is visible to them. |
@@ -401,6 +401,24 @@ Change the title size
 style: |
   .title {
     font-size: var(--ha-font-size-l);
+  }
+```
+
+Change the height of the title-card overlay - match arrow height.
+
+```yaml
+style: |
+  .header-overlay {
+    height: unset !important;
+  }
+```
+
+Change the height of title-card overlay - relative to title-card. The CSS var `--expander-card-overlay-height` is set automatically based on title-card height and overlay margin.
+
+```yaml
+style: |
+  .header-overlay {
+    height: calc(var(--expander-card-overlay-height) * 0.66 ) !important;
   }
 ```
 

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -276,14 +276,15 @@
 
         if (config['title-card-clickable'] && config['title-card-button-overlay'] && titleCardDiv) {
             const resizeObserver = new ResizeObserver(() => {
-                if (buttonElement && titleCardDiv &&expanderCard) {
+                if (buttonElement && titleCardDiv && expanderCard) {
                     const titleRect = titleCardDiv.getBoundingClientRect();
                     // While margin/padding set by expander-card is equal, users may have styled different margin/padding
-                    buttonElement.style.height = `${titleRect.height -
+                    expanderCard.style.setProperty('--expander-card-overlay-height', `${titleRect.height -
                         parseFloat(getComputedStyle(buttonElement).marginTop) -
                         parseFloat(getComputedStyle(buttonElement).marginBottom) +
                         parseFloat(getComputedStyle(expanderCard).paddingTop) +
-                        parseFloat(getComputedStyle(expanderCard).paddingBottom)}px`;
+                        parseFloat(getComputedStyle(expanderCard).paddingBottom)}px`
+                    );
                 }
             });
             resizeObserver.observe(titleCardDiv);
@@ -479,6 +480,7 @@
         top: 0;
         right: 0;
         margin: var(--overlay-margin);
+        height: var(--expander-card-overlay-height, auto);
     }
     .title-card-header-overlay.clickable  > .header-overlay {
         width: calc(100% - var(--overlay-margin) * 2);

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -72,6 +72,7 @@
     let animationState: AnimationState = $state<AnimationState>('idle');
     let animationTimeout: ReturnType<typeof setTimeout> | null = $state(null);
     let backgroundAnimationDuration = $state(0);
+    let overlayHeight = $state(0);
     let expanderCard: HTMLElement | null = $state(null);
     let titleCardDiv: HTMLElement | null = $state(null);
     let buttonElement: HTMLElement | null = $state(null);
@@ -279,12 +280,11 @@
                 if (buttonElement && titleCardDiv && expanderCard) {
                     const titleRect = titleCardDiv.getBoundingClientRect();
                     // While margin/padding set by expander-card is equal, users may have styled different margin/padding
-                    expanderCard.style.setProperty('--expander-card-overlay-height', `${titleRect.height -
+                    overlayHeight = titleRect.height -
                         parseFloat(getComputedStyle(buttonElement).marginTop) -
                         parseFloat(getComputedStyle(buttonElement).marginBottom) +
                         parseFloat(getComputedStyle(expanderCard).paddingTop) +
-                        parseFloat(getComputedStyle(expanderCard).paddingBottom)}px`
-                    );
+                        parseFloat(getComputedStyle(expanderCard).paddingBottom);
                 }
             });
             resizeObserver.observe(titleCardDiv);
@@ -319,6 +319,7 @@
          config['expander-card-background-expanded'] ?
          config['expander-card-background-expanded'] : config['expander-card-background']};
      --background-animation-duration:{backgroundAnimationDuration}s;
+     --expander-card-overlay-height:{overlayHeight ? `${overlayHeight}px` : 'auto'};
     "
     bind:this={expanderCard}>
     {#if config['title-card']}
@@ -481,6 +482,7 @@
         right: 0;
         margin: var(--overlay-margin);
         height: var(--expander-card-overlay-height, auto);
+        z-index: 1;
     }
     .title-card-header-overlay.clickable  > .header-overlay {
         width: calc(100% - var(--overlay-margin) * 2);


### PR DESCRIPTION
If you wish to have overlay with height match pre version 4.0.2, style `.header-overlay` and set `height: unset;`. See readme for full example.