### PR TITLE
fix: expander-card with storage-id will always be open after using UI edit mode.

### DIFF
--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -112,16 +112,20 @@
                     // first time, set the state from config
                     if (config.expanded !== undefined) {
                         setOpenState(config.expanded);
+                    } else {
+                        setOpenState(false);
                     }
                 }
                 else {
                     // last state is stored in local storage
-                    open = storageValue ? storageValue === 'true' : open;
+                    const openStateByStorage = storageValue ? storageValue === 'true' : open;
+                    setOpenState(openStateByStorage);
                 }
             } catch (e) {
                 console.error(e);
+                setOpenState(false);
             }
-        }else{
+        } else {
             // first time, set the state from config
             if (config.expanded !== undefined) {
                 setOpenState(config.expanded);
@@ -160,7 +164,7 @@
 
     function setOpenState(openState: boolean) {
         open = openState;
-        if (configId !== undefined) {
+        if (!preview && configId !== undefined) {
             try {
                 localStorage.setItem(lastStorageOpenStateId, open ? 'true' : 'false');
             } catch (e) {


### PR DESCRIPTION
No rush on this one. Just noticed while testing expander-card-id PR.