### PR TITLE
feat: Allow expanded config to be a javascript template

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ Javascript for variables and templates are set using `value_template` string, en
 
 Variables are defined in the `variables` list of expander card config.
 
+**IMPORTANT**: As variables are evaluated asynchronously, their initial value will be `undefined`. Your templates need to be written to handle this initial case.
+
 | List item | Type | Config |
 | --------- | ---- | ------ |
 | `variable` | string | The `<name>` of the variable which will be available in templates as `variable.<name>`. |
@@ -303,7 +305,7 @@ templates:
        ]]]
 ```
 
-Same template using variable `weather_warnings`.
+Same template using variable `weather_warnings`. Note the use of the nullish coalescing (??) operator to handle variables being undefined until their value is set.
 
 ```yaml
 variables:
@@ -316,7 +318,7 @@ templates:
   - template: expanded
     value_template: |
        [[[
-         return variables.weather_warnings;
+         return variables.weather_warnings ?? false;
        ]]]
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Yaml Options:
 | expanded-gap              | string   | _0.6em_       | css-size               | gap between child cards when expander open            |
 | child-padding             | string   | _0.0em_       | css-size               | padding of child cards                                |
 | child-margin-top          | string   | _0.0em_       | css-size               | Margin top of child cards                             |
-| clear-children            | boolean  | _false_       | true\|false            | Remove Background, border from childs                                   |
+| clear-children            | boolean  | _false_       | true\|false            | Remove Background, border from children                                   |
 | title-card                | object   | **optional**  | LovelaceCardConfig     | Replace Title with card                               |
 | title-card-clickable      | boolean  | _false_       | true\|false            | Should the complete div be clickable?               |
 | title-card-button-overlay | boolean  | _false_       | true\|false            | Overlay expand button over title-card. If you set `title-card-clickable: true` the overlay will extend across the expander, both horizontally and vertically, and capture the click before the title-card. If you wish to adjust the overlay height you can style `height` on `.header-overlay`. See [Style](#style) |
@@ -74,6 +74,8 @@ Yaml Options:
 | start-expanded-users      | object[] | **optional**  | *                      | Choose the persons/users that card will be start expanded for them. |
 | cards                     | object[] | **optional**  | LovelaceCardConfig[]   | Child cards to show when expanded                     |
 | style                     | string   | **optional**. | css style rules        | Advanced css styling rules. if you wish to style/hide the hover/press ripple of the expander-card button you can use advanced styling. See [Hover/press ripple](#hoverpress-ripple). |
+| variables                 | dictionary | **optional**| List                   | See Advanced javascript templates |
+| templates                 | dictionary | **optional**| List                   | See Advanced javascript templates |
 
 ## Examples
 
@@ -123,7 +125,7 @@ Example title card that is clickable and has 2 nested cards, which is directly e
 
 ### Heading Title card
 
-Example with [heading](https://www.home-assistant.io/dashboards/heading/) title card to the possiblity to style your title.
+Example with [heading](https://www.home-assistant.io/dashboards/heading/) title card to the possibility to style your title.
 
 ```yaml
       - type: custom:expander-card
@@ -218,7 +220,7 @@ Example with title that is clickable and has 2 nested cards with are automatical
             show_wind: speed
 ```
 
-### Title card with action 
+### Title card with action
 
 The configuration below will open or close the expander when you tap the Mushroom Light Card. This means you cannot switch the light on or off by tapping it, but you can still adjust the brightness.
 
@@ -244,6 +246,81 @@ The configuration below will open or close the expander when you tap the Mushroo
             expander-card-id: my-light-card
             action: toggle
 ```
+
+## Advanced javascript templates
+
+Expander card supports javascript templates for the config items listed below. This list may be added to over time based on user feature requests. If you wish for a config item to be supported by javascript template please submit a feature request.
+
+| Config item | Accepts value | Overrides config items |
+| ----------- | ------------- | ---------------------- |
+| `expanded`  | boolean (`true\|false`) | `expanded`, `min-width-expanded`, `max-width-expanded`, `start-expanded-users` |
+
+Javascript templates are implemented using the [home-assistant-javascript-templates](https://github.com/elchininet/home-assistant-javascript-templates) library by @elchininet. For objects and methods supported see [Objects and methods available in the templates](https://github.com/elchininet/home-assistant-javascript-templates#objects-and-methods-available-in-the-templates). The `config` object is also available which is the config object for the expander card where all config items can be read. e.g. `config['expander-card-id']`.
+
+Templates may also use `variables`, which are also javascript templates or just values. Templates are reactive to `variables` such that if a variable template value changes, the template using the variable itself will be evaluated and return its value. Expander card uses the [home-assistant-javascript-templates](https://github.com/elchininet/home-assistant-javascript-templates) `refs` feature using `variables` as the `refsVariableName`. You are best to ignore anything about `refs` in the library unless you know what you are doing.
+
+Templates are not continually evaluated but rely on reactive properties for updates. Follow the guidelines in [Objects and methods available in the templates](https://github.com/elchininet/home-assistant-javascript-templates#objects-and-methods-available-in-the-templates).
+
+Javascript for variables and templates are set using `value_template` string, enclosing javascript with `[[[]]]`, that is three open square bracket `[[[` followed by three close square bracket `]]]`. This follows the convention followed by other custom cards for javascript templates. Variables and templates can also return a straight value, which will follow YAML syntax converted to the type required for the config item being templated e.g. for a config item that accepts `boolean`, `true`, `"True"`, `1`, `"1"` are all considered `true`.
+
+### Variables
+
+Variables are defined in the `variables` list of expander card config.
+
+| List item | Type | Config |
+| --------- | ---- | ------ |
+| `variable` | string | The `<name>` of the variable which will be available in templates as `variable.<name>`. |
+| `value_template` | string \| value \| object | Either javascript that returns a value or a straight value. Javascript must be enclosed by `[[[]]]` with only whitespace preceding of following. |
+
+Variable `weather_warnings` tracking the state of `input_boolean.weather_warnings`.
+
+```yaml
+variables:
+  - variable: weather_warnings
+    value_template: |
+      [[[
+        return is_state('input_boolean.weather_warnings', 'on');
+      ]]]
+```
+
+### Templates
+
+Templates are defined in the `templates` list of expander card config.
+
+| List item | Type | Config |
+| --------- | ---- | ------ |
+| `template` | string | The config item being templated. Only supported config items will be read by expander card. See list in main [Advanced javascript templates](#advanced-javascript-templates) section. |
+| `value_template` | string \| value \| object | Either javascript that returns a value or a straight value. Javascript must be enclosed by `[[[]]]` with only whitespace preceding of following. The type of the value \| object returned/set must be applicable to the config item being templated. |
+
+Template for `expanded` config item tracking state of `input_boolean.weather_warnings`.
+
+```yaml
+templates:
+  - template: expanded
+    value_template: |
+       [[[
+         return is_state('input_boolean.weather_warnings', 'on');
+       ]]]
+```
+
+Same template using variable `weather_warnings`.
+
+```yaml
+variables:
+  - variable: weather_warnings
+    value_template: |
+      [[[
+        return is_state('input_boolean.weather_warnings', 'on');
+      ]]]
+templates:
+  - template: expanded
+    value_template: |
+       [[[
+         return variables.weather_warnings;
+       ]]]
+```
+
+More user examples can be found in [Show and tell](https://github.com/MelleD/lovelace-expander-card/discussions/categories/show-and-tell) discussion topic. If you have an example please submit to this discussion topic.
 
 ## Set state via action
 
@@ -449,7 +526,7 @@ style: |
 | `--ha-ripple-hover-color` | Hover ripple color. Set if you wish it to be different from pressed color. | CSS color | `var(--ha-ripple-color, var(--secondary-text-color))` |
 | `--ha-ripple-pressed-color` | Pressed ripple color. Set if you wish to be different from hover color. | CSS color | `var(--ha-ripple-color, var(--secondary-text-color))` |
 | `--ha-ripple-hover-opacity` | Opacity of the hover ripple. | CSS opacity | 0.08 |
-| `--ha-ripple-pressed-opacity` | Opacity of the pressed ripple. | CSS opacity | 0.12 | 
+| `--ha-ripple-pressed-opacity` | Opacity of the pressed ripple. | CSS opacity | 0.12 |
 
 ## Card Mod
 
@@ -462,7 +539,7 @@ Before the `style` attribute, [card mod](https://github.com/thomasloven/lovelace
 Expander-Card is available in [HACS][hacs] (Home Assistant Community Store) by default.
 
 1. Install HACS if you don't have it already
-2. Open HACS in Home Assistant 
+2. Open HACS in Home Assistant
 3. Searching for expander card
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=MelleD&repository=lovelace-expander-card&category=plugin)
@@ -487,8 +564,8 @@ Expander-Card is available in [HACS][hacs] (Home Assistant Community Store) by d
 ### Issue after upgrade to HA 2025.6
 
 There is/was an issue after upgrading to HA 2025.6 (maybe with newer version is not valid anymore)
-See [forum](https://community.home-assistant.io/t/expander-accordion-collapsible-card/738817/56?u=melled) and [issue](https://github.com/MelleD/lovelace-expander-card/issues/506) 
-a) For the view type [sections](https://www.home-assistant.io/blog/2024/03/04/dashboard-chapter-1/) `cards` is not working anymore. You have to rename it to `sections`.
+See [forum](https://community.home-assistant.io/t/expander-accordion-collapsible-card/738817/56?u=melled) and [issue](https://github.com/MelleD/lovelace-expander-card/issues/506).
+For the view type [sections](https://www.home-assistant.io/blog/2024/03/04/dashboard-chapter-1/) `cards` is not working anymore. You have to rename it to `sections`.
 
 Before
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "vite": "^6.4.1"
     },
     "dependencies": {
+        "home-assistant-javascript-templates": "^6.0.0",
         "svelte": "5.45.8"
     },
     "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      home-assistant-javascript-templates:
+        specifier: ^6.0.0
+        version: 6.0.0
       svelte:
         specifier: 5.45.8
         version: 5.45.8
@@ -1154,9 +1157,6 @@ packages:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
 
-  devalue@5.3.2:
-    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
-
   devalue@5.6.1:
     resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
 
@@ -1309,6 +1309,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-promisable-result@1.0.1:
+    resolution: {integrity: sha512-hUUKs/s8qoeH4gk3NPcKjCWaCjOv0S+kyT3oTuJXneEWYzwmyfEJHESU2ES7pMZNVHTjMt7X8hpmThFfggTVtg==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1328,6 +1331,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  home-assistant-javascript-templates@6.0.0:
+    resolution: {integrity: sha512-3C3gI+clPpbVm3/h/rR3ahkERSRyhRzia5Q9E3+iuT2w29Dr8s72LASfETAUx82iEiJurAmysaDfLFWVbShXJQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2602,7 +2608,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
-      devalue: 5.3.2
+      devalue: 5.6.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.19
@@ -2873,8 +2879,6 @@ snapshots:
 
   detect-libc@2.0.4: {}
 
-  devalue@5.3.2: {}
-
   devalue@5.6.1: {}
 
   electron-to-chromium@1.5.267: {}
@@ -3057,6 +3061,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-promisable-result@1.0.1: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -3070,6 +3076,10 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  home-assistant-javascript-templates@6.0.0:
+    dependencies:
+      get-promisable-result: 1.0.1
 
   ignore@5.3.2: {}
 

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -16,7 +16,7 @@ limitations under the License.
 <svelte:options customElement='expander-sub-card' />
 
 <script lang="ts">
-    import { onMount } from 'svelte';
+    import { onMount, untrack } from 'svelte';
     import type { AnimationState, HomeAssistant, HuiCard, LovelaceCardConfig } from './types';
     import { computeCardSize } from './helpers/compute-card-size';
 
@@ -44,7 +44,7 @@ limitations under the License.
     let container = $state<HuiCard | null>(null);
     let loading = $state(true);
     let cardHeight = $state(0);
-    const cardConfig: LovelaceCardConfig = JSON.parse(JSON.stringify(config));
+    const cardConfig: LovelaceCardConfig = untrack(() => JSON.parse(JSON.stringify(config)));
     $effect(() => {
         if (container) {
             container.hass = hass;

--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -93,7 +93,7 @@
             setOpenState(true);
             showButtonUsers = true;
         } else {
-            if (!isJSTemplate(config.expanded)) {
+            if (!isJSTemplate(config.templates?.expanded)) {
                 setDefaultOpenState();
             }
             showButtonUsers = userInList(config['show-button-users']) ?? true;
@@ -109,7 +109,7 @@
 
     function setDefaultOpenState() {
         // Do not run setDefaultOpenState if config.expanded is a JS template
-        if (isJSTemplate(config.expanded)) return;
+        if (isJSTemplate(config.templates?.expanded)) return;
         if (userInList(config['start-expanded-users'])) {
             setOpenState(true);
         } else if (configId !== undefined) {
@@ -118,7 +118,7 @@
                 if(storageValue === null){
                     // first time, set the state from config
                     if (config.expanded !== undefined) {
-                        setOpenState(Boolean(config.expanded));
+                        setOpenState(config.expanded);
                     } else {
                         setOpenState(false);
                     }
@@ -135,7 +135,7 @@
         } else {
             // first time, set the state from config
             if (config.expanded !== undefined) {
-                setOpenState(Boolean(config.expanded));
+                setOpenState(config.expanded);
             } else {
                 setOpenState(false);
             }
@@ -252,14 +252,14 @@
     };
 
     const bindTemplateVariables = (haJS: Promise<HomeAssistantJavaScriptTemplatesRenderer>) => {
-        for (const [k, v] of Object.entries(config.variables ?? {})) {
+        for (const [k, v] of Object.entries(config.templates?.variables ?? {})) {
             if (isJSTemplate(v)) {
                 trackJSTemplate(
                     haJS,
                     (res) => {
                         setJSTemplateRef(haJS, k, res);
                     },
-                    v as string,
+                    v,
                     { config: config }
                 );
             } else {
@@ -269,8 +269,8 @@
     };
 
     onMount(() => {
-        if (isJSTemplate(config.expanded)) {
-            const refs = Object.keys(config.variables || {}).reduce(
+        if (config.templates?.expanded && isJSTemplate(config.templates.expanded)) {
+            const refs = Object.keys(config.templates?.variables || {}).reduce(
                 (obj, key) => {
                     obj[key] = undefined;
                     return obj;
@@ -292,7 +292,7 @@
                         }
                     }
                 },
-                config.expanded as string,
+                config.templates.expanded,
                 { config: config }
             );
         } else {
@@ -311,7 +311,7 @@
 
         if (preview) {
             setOpenState(true);
-        } else if (!isJSTemplate(config.expanded)) {
+        } else if (!isJSTemplate(config.templates?.expanded)) {
             setDefaultOpenState();
         }
 

--- a/src/ExpanderCardEditor.ts
+++ b/src/ExpanderCardEditor.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ExpanderCardEditorNulls, ExpanderCardEditorSchema } from './editortype';
+import { ExpanderCardEditorNulls, ExpanderCardEditorSchema, expanderCardEditorTemplates } from './editortype';
 import { HomeAssistantUser } from './types';
 
 const wdw = window; // NOSONAR es2019
@@ -56,7 +56,12 @@ const loader = async (): Promise<any> => {
             const usersEscaped = this._users
                 .map((u: string) => u.replace(/\\/g, '\\\\').replace(/"/g, '\\"')) // NOSONAR es2019
                 .join('","');
-            const populatedSchemaJSON = schemaJSON.replace(/\[\[users\]\]/g, usersEscaped); // NOSONAR es2019
+            let populatedSchemaJSON = schemaJSON.replace(/\[\[users\]\]/g, usersEscaped); // NOSONAR es2019
+            // populate templates options, but only those not already in config
+            populatedSchemaJSON = populatedSchemaJSON.replace(/\[\[templates\]\]/g, // NOSONAR es2019
+                expanderCardEditorTemplates
+                    .filter((t: any) => !this._config.templates?.some((ct: any) => ct.template === t))
+                    .join('","'));
             const populatedSchema = JSON.parse(populatedSchemaJSON);
             return populatedSchema;
         }

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -11,7 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import type { LovelaceCardConfig } from './types';
+export interface ExpanderCardVariables  {
+    variable: string;
+    value_template: unknown;
+}
 
+export interface ExpanderCardTemplates {
+    template: string;
+    value_template: unknown;
+}
 export interface ExpanderConfig {
     clear?: boolean;
     'clear-children'?: boolean;
@@ -44,8 +52,6 @@ export interface ExpanderConfig {
     animation?: boolean;
     'expander-card-id'?: string;
     style?: string;
-    templates?: {
-        variables?: Record<string, string>;
-        expanded?: string;
-    };
+    variables?: Record<string, ExpanderCardVariables>;
+    templates?: Record<string, ExpanderCardTemplates>;
 }

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -27,7 +27,7 @@ export interface ExpanderConfig {
     'overlay-margin'?: string;
     'child-padding'?: string;
     'child-margin-top'?: string;
-    expanded?: boolean;
+    expanded?: boolean | string;
     'expander-card-background'?: string;
     'expander-card-background-expanded'?: string;
     'header-color'?: string;
@@ -44,4 +44,5 @@ export interface ExpanderConfig {
     animation?: boolean;
     'expander-card-id'?: string;
     style?: string;
+    variables?: Record<string, unknown>;
 }

--- a/src/configtype.ts
+++ b/src/configtype.ts
@@ -27,7 +27,7 @@ export interface ExpanderConfig {
     'overlay-margin'?: string;
     'child-padding'?: string;
     'child-margin-top'?: string;
-    expanded?: boolean | string;
+    expanded?: boolean;
     'expander-card-background'?: string;
     'expander-card-background-expanded'?: string;
     'header-color'?: string;
@@ -44,5 +44,8 @@ export interface ExpanderConfig {
     animation?: boolean;
     'expander-card-id'?: string;
     style?: string;
-    variables?: Record<string, unknown>;
+    templates?: {
+        variables?: Record<string, string>;
+        expanded?: string;
+    };
 }

--- a/src/editortype.ts
+++ b/src/editortype.ts
@@ -26,6 +26,10 @@ export const ExpanderCardEditorNulls: ExpanderConfig = {
     'style': ''
 };
 
+export const expanderCardEditorTemplates = [
+    'expanded'
+];
+
 const iconSelector = { icon: {} };
 const textSelector = { text: {} };
 const multilineTextSelector = { text: { multiline: true } };
@@ -260,6 +264,77 @@ export const ExpanderCardEditorSchema = [
                 schema: [
                     {
                         ...multilineTextField('style', 'Custom CSS style')
+                    }
+                ]
+            },
+            {
+                type: 'expandable',
+                label: 'Advanced templates',
+                icon: 'mdi:code-brackets',
+                schema: [
+                    {
+                        type: 'expandable',
+                        label: 'Variables',
+                        icon: 'mdi:variable',
+                        schema: [
+                            {
+                                name: 'variables',
+                                label: 'Variables',
+                                selector: {
+                                    object: {
+                                        label_field: 'variable',
+                                        multiple: true,
+                                        fields: {
+                                            variable: {
+                                                label: 'Variable name',
+                                                required: true,
+                                                selector: { text: {} }
+                                            },
+                                            value_template: {
+                                                label: 'Value template',
+                                                required: true,
+                                                selector: { text: { multiline: true } }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        type: 'expandable',
+                        label: 'Templates',
+                        icon: 'mdi:code-brackets',
+                        schema: [
+                            {
+                                name: 'templates',
+                                label: 'Templates',
+                                selector: {
+                                    object: {
+                                        label_field: 'template',
+                                        multiple: true,
+                                        fields: {
+                                            template: {
+                                                label: 'Config item',
+                                                required: true,
+                                                selector: {
+                                                    select: {
+                                                        mode: 'dropdown',
+                                                        sort: true,
+                                                        options: ['[[templates]]'] // to be populated dynamically
+                                                    }
+                                                }
+                                            },
+                                            value_template: {
+                                                label: 'Value template',
+                                                required: true,
+                                                selector: { text: { multiline: true } }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
                     }
                 ]
             }

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -12,7 +12,7 @@ export function getJSTemplateRenderer(variables: Record<string, unknown> = {}, r
     ).getRenderer();
 }
 
-export function isJSTemplate(template: unknown): boolean {
+export function isJSTemplate(template: string | undefined): boolean {
     if (!template || typeof template !== 'string') return false;
     return String(template).trim().startsWith('[[[') && String(template).trim().endsWith(']]]');
 }

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -1,8 +1,8 @@
-import HomeAssistantJavaScriptTemplates, { HomeAssistantJavaScriptTemplatesRenderer } from 'home-assistant-javascript-templates';
+import HomeAssistantJavaScriptTemplates, { HomeAssistant, HomeAssistantJavaScriptTemplatesRenderer } from 'home-assistant-javascript-templates';
 
 export function getJSTemplateRenderer(variables: Record<string, unknown> = {}, refs: Record<string, unknown> = {}): Promise<HomeAssistantJavaScriptTemplatesRenderer> {
     return new HomeAssistantJavaScriptTemplates(
-        document.querySelector('home-assistant')!,
+        document.querySelector('home-assistant') as HomeAssistant,
         {
             autoReturn: false,
             variables,

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -1,0 +1,52 @@
+import HomeAssistantJavaScriptTemplates, { HomeAssistantJavaScriptTemplatesRenderer } from 'home-assistant-javascript-templates';
+
+export function getJSTemplateRenderer(variables: Record<string, unknown> = {}, refs: Record<string, unknown> = {}): Promise<HomeAssistantJavaScriptTemplatesRenderer> {
+    return new HomeAssistantJavaScriptTemplates(
+        document.querySelector('home-assistant')!,
+        {
+            autoReturn: false,
+            variables,
+            refs,
+            refsVariableName: 'variables'
+        }
+    ).getRenderer();
+}
+
+export function isJSTemplate(template: unknown): boolean {
+    if (!template || typeof template !== 'string') return false;
+    return String(template).trim().startsWith('[[[') && String(template).trim().endsWith(']]]');
+}
+
+export function renderJSTemplate(
+    templatesRenderer: Promise<HomeAssistantJavaScriptTemplatesRenderer>,
+    template: string,
+    variables: Record<string, unknown> = {}) {
+    if (!isJSTemplate(template)) {
+        throw new Error('Not a valid JS template');
+    }
+    template = String(template).trim().slice(3, -3);
+    void templatesRenderer.then((renderer) => renderer.renderTemplate(template, { variables } ));
+}
+
+export function trackJSTemplate(
+    templatesRenderer: Promise<HomeAssistantJavaScriptTemplatesRenderer>,
+    callback: (result: unknown) => void,
+    template: string,
+    variables: Record<string, unknown> = {}) {
+    if (!isJSTemplate(template)) {
+        throw new Error('Not a valid JS template');
+    }
+    template = String(template).trim().slice(3, -3);
+    void templatesRenderer.then((renderer) => {
+        renderer.trackTemplate(template, callback, { variables });
+    });
+}
+
+export function setJSTemplateRef(
+    templatesRenderer: Promise<HomeAssistantJavaScriptTemplatesRenderer>,
+    refName: string,
+    refValue: unknown) {
+    void templatesRenderer.then((renderer) => {
+        renderer.refs[refName] = refValue;
+    });
+}

--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -12,7 +12,7 @@ export function getJSTemplateRenderer(variables: Record<string, unknown> = {}, r
     ).getRenderer();
 }
 
-export function isJSTemplate(template: string | undefined): boolean {
+export function isJSTemplate(template: unknown): boolean {
     if (!template || typeof template !== 'string') return false;
     return String(template).trim().startsWith('[[[') && String(template).trim().endsWith(']]]');
 }


### PR DESCRIPTION
Closes #212 

Also fixes svelte warnings for latest versions by using untrack() where we don't track states of reactive variables and only wish to get their state on init.