### PR TITLE
fix: set correct expanded state after edit/preview when using template for expanded state

### DIFF
--- a/src/helpers/templates.ts
+++ b/src/helpers/templates.ts
@@ -32,14 +32,12 @@ export function trackJSTemplate(
     templatesRenderer: Promise<HomeAssistantJavaScriptTemplatesRenderer>,
     callback: (result: unknown) => void,
     template: string,
-    variables: Record<string, unknown> = {}) {
+    variables: Record<string, unknown> = {}): Promise<(() => void)> {
     if (!isJSTemplate(template)) {
         throw new Error('Not a valid JS template');
     }
     template = String(template).trim().slice(3, -3);
-    void templatesRenderer.then((renderer) => {
-        renderer.trackTemplate(template, callback, { variables });
-    });
+    return templatesRenderer.then((renderer) => renderer.trackTemplate(template, callback, { variables }));
 }
 
 export function setJSTemplateRef(


### PR DESCRIPTION
Fixes #824 

Also untrack variables and templates in cleanup()