### PR TITLE
fix: Only define expander-card-title-card-edit-form when not defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,4 +41,6 @@ window.customCards.push(...[ // NOSONAR es2019
     }
 ]);
 
-customElements.define('expander-card-title-card-edit-form', TitleCardEditForm);
+if (!customElements.get('expander-card-title-card-edit-form')) {
+    customElements.define('expander-card-title-card-edit-form', TitleCardEditForm);
+}


### PR DESCRIPTION
Fixes #836 