### PR TITLE
fix: sonar warning in github actions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -2,7 +2,7 @@ name: 'Label PR'
 
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
     branches:
       - main
 

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -75,9 +75,7 @@ jobs:
           target_commitish: main
           draft: false
           prerelease: "$PRE_RELEASE"
-          files: |
-            release-artifacts/*.zip
-            release-artifacts/checksums.txt
+          files: dist/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -66,19 +66,24 @@ jobs:
           path: docs/site
       - uses: actions/deploy-pages@v4
 
-      - name: "Create Github release (full)"
-        uses: softprops/action-gh-release@v2
-        id: expander_card_release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b #v2
+        id: github_release
         with:
-          body: "Release version ${{ github.event.inputs.release_version }}."
-          tag_name: ${{ github.event.inputs.release_version }}
-          target_commitish: "main"
+          name: "Release v$VERSION"
+          tag_name: "$TAG_NAME"
+          target_commitish: main
           draft: false
-          prerelease: ${{ github.event.inputs.prerelease }}
-          files: dist/*
+          prerelease: "$PRE_RELEASE"
+          files: |
+            release-artifacts/*.zip
+            release-artifacts/checksums.txt
           generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.event.inputs.release_version }}
+          TAG_NAME: ${{ github.event.inputs.release_version }}
+          PRE_RELEASE: ${{ github.event.inputs.prerelease }}
 
       - name: "Notify issues of release their fix is contained in"
         if: ${{ !github.event.inputs.prerelease }}


### PR DESCRIPTION
Updated GitHub release action to use a specific commit SHA and modified parameters for release creation.