### PR TITLE
chore: Add 'docs/**/*' and '.venv/**/*' to ignored eslint files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,7 @@ export default tseslint.config(
     ...tseslint.configs.recommended,
     ...eslintPluginSvelte.configs['flat/recommended'],
     {
-        ignores: ['eslint.config.mjs','rollup.config.mjs','dist/**/*','vite.config.js', 'svelte.config.js', 'eslint.config.js', '.svelte-kit/**/*', 'build/**/*'],
+        ignores: ['eslint.config.mjs','rollup.config.mjs','dist/**/*','vite.config.js', 'svelte.config.js', 'eslint.config.js', '.svelte-kit/**/*', 'build/**/*', 'docs/**/*', '.venv/**/*'],
     },
     {
         plugins: {


### PR DESCRIPTION
Any js files in these directories are currently being pulled pu by linter and my cause build errors.