### PR TITLE
fix: Update default font and size of title to match Home Assistant defaults

### DIFF
--- a/src/ExpanderCard.svelte
+++ b/src/ExpanderCard.svelte
@@ -693,6 +693,8 @@
         color: var(--header-color,#fff);
         cursor: pointer;
         position: relative;
+        font-family: var(--ha-font-family-body);
+        font-size: var(--ha-font-size-m);
     }
     .header-overlay {
         position: absolute;


### PR DESCRIPTION
BREAKING: Title font family and size are now set to match Home Assistant theme font family and size. Font family is set by theme CSS var `--ha-font-family-body`. Font size is set by theme CSS var `--ha-font-size-m`. For default Home Assistant theme this will change the font family from your Browser's default (commonly Arial) to **Roboto, Noto, sans-serif** and change font size from Browser default for button (commonly 0.95em/13.333px) to **14px**. You can adjust to suit using Expander card [styling](https://melled.github.io/lovelace-expander-card/chapter/style/).

Fixes #895 