### PR TITLE
fix: Don't clear border radius with clear-children

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -96,7 +96,6 @@ limitations under the License.
             el.style.setProperty('--ha-card-box-shadow', 'none');
             el.style.setProperty('--ha-card-border-color', 'transparent');
             el.style.setProperty('--ha-card-border-width', '0px');
-            el.style.setProperty('--ha-card-border-radius', '0px');
             el.style.setProperty('--ha-card-backdrop-filter', 'none');
         }
 


### PR DESCRIPTION
BREAKING: clear-children no longer sets `--ha-card-border-radius: 0px`. `--ha-card-border-color` is still transparet and  `--ha-card-border-width` is still 0px. The main change this will have is that any action ripples on children, including title-card now will have a border radius. If you wish a square ripple for title-card and children, you will need to set `--ha-card-border-radius: 0px` on the relevant container class.

Fixes #906 