### PR TITLE
fix: Title card editor updated to fix missing title and buttons after update to Home Assistant 2026.3.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "content_in_root": false,
     "render_readme": true,
     "filename": "expander-card.js",
-    "homeassistant": "2025.10.0b0"
+    "homeassistant": "2025.3.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "content_in_root": false,
     "render_readme": true,
     "filename": "expander-card.js",
-    "homeassistant": "2025.3.0"
+    "homeassistant": "2026.3.0"
 }

--- a/src/helpers/ha-dialog-styles.ts
+++ b/src/helpers/ha-dialog-styles.ts
@@ -1,8 +1,8 @@
 import { css } from 'lit';
 
 export const haStyleDialog = css`
-  /* mwc-dialog (ha-dialog) styles */
-  ha-dialog {
+  ha-dialog,
+  ha-adaptive-dialog {
     --mdc-dialog-min-width: 400px;
     --mdc-dialog-max-width: 600px;
     --mdc-dialog-max-width: min(600px, 95vw);
@@ -13,7 +13,8 @@ export const haStyleDialog = css`
     --dialog-surface-padding: 0px;
   }
 
-  ha-dialog .form {
+  ha-dialog .form,
+  ha-adaptive-dialog .form {
     color: var(--primary-text-color);
   }
 
@@ -23,7 +24,8 @@ export const haStyleDialog = css`
 
   /* make dialog fullscreen on small screens */
   @media all and (max-width: 450px), all and (max-height: 500px) {
-    ha-dialog {
+    ha-dialog,
+    ha-adaptive-dialog {
       --mdc-dialog-min-width: 100vw;
       --mdc-dialog-max-width: 100vw;
       --mdc-dialog-min-height: 100vh;
@@ -35,6 +37,8 @@ export const haStyleDialog = css`
         var(--safe-area-inset-right, 0) var(--safe-area-inset-bottom, 0)
         var(--safe-area-inset-left, 0);
       --vertical-align-dialog: flex-end;
+    }
+    ha-dialog {
       --ha-dialog-border-radius: var(--ha-border-radius-square);
     }
   }
@@ -44,7 +48,8 @@ export const haStyleDialog = css`
 `;
 
 export const haStyleDialogFixedTop = css`
-  ha-dialog {
+  ha-dialog,
+  ha-adaptive-dialog {
     /* Pin dialog to top so it doesn't jump when content changes size */
     --vertical-align-dialog: flex-start;
     --dialog-surface-margin-top: var(--ha-space-10);
@@ -60,16 +65,31 @@ export const haStyleDialogFixedTop = css`
           0px
         )
     );
+    --ha-dialog-max-height: calc(
+      100vh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
+          --safe-area-inset-y,
+          0px
+        )
+    );
+    --ha-dialog-max-height: calc(
+      100svh - var(--dialog-surface-margin-top) - var(--ha-space-2) - var(
+          --safe-area-inset-y,
+          0px
+        )
+    );
   }
 
   @media all and (max-width: 450px), all and (max-height: 500px) {
-    ha-dialog {
+    ha-dialog,
+    ha-adaptive-dialog {
       /* When in fullscreen, dialog should be attached to top */
       --dialog-surface-margin-top: 0px;
       --mdc-dialog-min-height: 100vh;
       --mdc-dialog-min-height: 100svh;
       --mdc-dialog-max-height: 100vh;
       --mdc-dialog-max-height: 100svh;
+      --ha-dialog-max-height: 100vh;
+      --ha-dialog-max-height: 100svh;
     }
   }
 `;

--- a/src/title-card/titleCardEditForm.ts
+++ b/src/title-card/titleCardEditForm.ts
@@ -100,8 +100,9 @@ export class TitleCardEditForm extends LitElement {
             @keydown=${this._ignoreKeydown.bind(this)}
             @closed=${ this._cancel.bind(this) }
             .heading=${heading}
+            .width=${this.large ? 'full' : 'large'}
         >
-            <ha-dialog-header slot="heading">
+            <ha-dialog-header slot="header">
                 <ha-icon-button
                     slot="navigationIcon"
                     dialogAction="cancel"
@@ -112,23 +113,26 @@ export class TitleCardEditForm extends LitElement {
                 <span slot="title" @click=${this._enlarge.bind(this)}>${heading}</span>
             </ha-dialog-header>
             ${this._renderCardEditor()}
-            <div slot="primaryAction" @click=${this._submit.bind(this)}>
-                <ha-button
-                    appearance="plain"
-                    size="small"
-                    @click=${this._cancel.bind(this)}
-                    dialogInitialFocus
-                >
-                    ${this._params.cancelText || this.hass.localize('ui.common.cancel')}
-                </ha-button>
-                <ha-button
-                    size="small"
-                    @click=${this._submit.bind(this)} 
-                    disabled=${ifDefined(disableSave)}
-                >
-                    ${this._params.submitText || this.hass.localize('ui.common.save')}
-                </ha-button>
-            </div>
+            <ha-dialog-footer slot="footer">
+                <div slot="primaryAction" @click=${this._submit.bind(this)}>
+                    <ha-button
+                        appearance="plain"
+                        size="small"
+                        @click=${this._cancel.bind(this)}
+                        dialogInitialFocus
+                    >
+                        ${this._params.cancelText || this.hass.localize('ui.common.cancel')}
+                    </ha-button>
+                    <ha-button
+                        size="small"
+                        @click=${this._submit.bind(this)} 
+                        disabled=${ifDefined(disableSave)}
+                    >
+                        ${this._params.submitText || this.hass.localize('ui.common.save')}
+                    </ha-button>
+                </div>
+                ${this._renderCardEditorActions()}
+            </ha-dialog-footer>
         </ha-dialog>
         `;
     }
@@ -212,7 +216,6 @@ export class TitleCardEditForm extends LitElement {
                     ${cardRenderBlurSpinner}
                 </div>
             </div>
-            ${this._renderCardEditorActions()}
             `
             : html`
             <hui-card-picker
@@ -231,49 +234,54 @@ export class TitleCardEditForm extends LitElement {
             :host {
                 --code-mirror-max-height: calc(100vh - 176px);
             }
+
             ha-dialog {
-                --mdc-dialog-max-width: 100px;
                 --dialog-z-index: 6;
-                --mdc-dialog-max-width: 90vw;
-                --dialog-content-padding: 24px 12px;
+                --dialog-content-padding: var(--ha-space-2);
             }
+
             .content {
-                width: calc(90vw - 48px);
-                max-width: 1000px;
+                width: 100%;
+                max-width: 100%;
             }
+
             @media all and (max-width: 450px), all and (max-height: 500px) {
-                /* overrule the ha-style-dialog max-height on small screens */
-                ha-dialog {
-                    height: 100%;
-                    --mdc-dialog-max-height: 100%;
-                    --dialog-surface-top: 0px;
-                    --mdc-dialog-max-width: 100vw;
-                }
+            /* overrule the ha-style-dialog max-height on small screens */
                 .content {
                     width: 100%;
                     max-width: 100%;
                 }
             }
+
             @media all and (min-width: 451px) and (min-height: 501px) {
                 :host([large]) .content {
                     max-width: none;
                 }
             }
+
+            .center {
+                margin-left: auto;
+                margin-right: auto;
+            }
+
             .content {
                 display: flex;
                 flex-direction: column;
-                gap: 24px;
             }
+
             .content hui-card {
                 display: block;
                 padding: 4px;
                 margin: 0 auto;
                 max-width: 390px;
             }
-            .content .element-editor {
-                margin: 0 10px;
+            .content hui-section {
+                display: block;
+                padding: 4px;
+                margin: 0 auto;
+                max-width: var(--ha-view-sections-column-max-width, 500px);
             }
-            .content .element-preview {
+            .content .element-editor {
                 margin: 0 10px;
             }
 
@@ -292,8 +300,10 @@ export class TitleCardEditForm extends LitElement {
                     margin: auto 0px;
                     max-width: 500px;
                 }
-                .content .element-preview {
-                    margin: unset;
+                .content hui-section {
+                    padding: 8px 10px;
+                    margin: auto 0px;
+                    max-width: var(--ha-view-sections-column-max-width, 500px);
                 }
             }
             .hidden {
@@ -336,6 +346,9 @@ export class TitleCardEditForm extends LitElement {
                 gap: var(--ha-space-2);
                 display: flex;
                 margin-left: 0px;
+                margin-right: auto;
+                margin-inline-end: auto;
+                margin-inline-start: initial;
             }
             [slot="navigationIcon"] {
                 --ha-icon-display: block;


### PR DESCRIPTION
Fixes #946 
BREAKING CHANGE: Requires Home Assistant 2026.3.0 or above.