### PR TITLE
test: Fix ha persistent server not being picked up correctly

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -63,7 +63,9 @@
     // Bash or WSL before running these tasks; PowerShell/cmd will not work.
     //
     // Each task uses the .venv binaries directly and loads .ha_env from the
-    // workspace root (if present)
+    // workspace root (if present). Keep the `${workspaceFolder}` prefix in the
+    // source command so tasks resolve .ha_env from the workspace root even if a
+    // VS Code terminal session was previously started in a different directory.
     // before running so that a pre-running HA instance started by
     // "HA: Start persistent server" is used automatically — no Docker boot
     // wait.  If .ha_env doesn't exist the dot-source silently fails and pytest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,8 @@
 {
   "version": "2.0.0",
+  "options": {
+    "cwd": "${workspaceFolder}"
+  },
   "tasks": [
     // -------------------------------------------------------------------------
     // Python — virtual environment setup
@@ -53,12 +56,14 @@
     // -------------------------------------------------------------------------
     // pytest — visual / integration tests
     //
-    // NOTE: These tasks use POSIX shell features (`. .ha_env`, env-var prefixes,
+    // NOTE: These tasks use POSIX shell features (`. "${workspaceFolder}/.ha_env"`,
+    // env-var prefixes,
     // `2>/dev/null`).  They require Bash (or another POSIX-compatible shell) as
     // the VS Code terminal shell.  On Windows, set your terminal profile to Git
     // Bash or WSL before running these tasks; PowerShell/cmd will not work.
     //
-    // Each task uses the .venv binaries directly and loads .ha_env (if present)
+    // Each task uses the .venv binaries directly and loads .ha_env from the
+    // workspace root (if present)
     // before running so that a pre-running HA instance started by
     // "HA: Start persistent server" is used automatically — no Docker boot
     // wait.  If .ha_env doesn't exist the dot-source silently fails and pytest
@@ -68,7 +73,7 @@
     {
       "label": "pytest: All tests",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; .venv/bin/pytest tests/",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; .venv/bin/pytest tests/",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -79,7 +84,7 @@
     {
       "label": "pytest: All tests (Update)",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; SNAPSHOT_UPDATE=1 DOC_IMAGE_UPDATE=1 .venv/bin/pytest tests/",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; SNAPSHOT_UPDATE=1 DOC_IMAGE_UPDATE=1 .venv/bin/pytest tests/",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -90,7 +95,7 @@
     {
       "label": "pytest: All scenarios",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; .venv/bin/pytest tests/visual/test_scenarios.py",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; .venv/bin/pytest tests/visual/test_scenarios.py",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -101,7 +106,7 @@
     {
       "label": "pytest: All scenarios (Update)",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; SNAPSHOT_UPDATE=1 .venv/bin/pytest tests/visual/test_scenarios.py",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; SNAPSHOT_UPDATE=1 .venv/bin/pytest tests/visual/test_scenarios.py",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -116,7 +121,7 @@
     {
       "label": "pytest: Run single scenario",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; .venv/bin/pytest tests/visual/test_scenarios.py -k '${input:scenarioId}'",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; .venv/bin/pytest tests/visual/test_scenarios.py -k '${input:scenarioId}'",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -127,7 +132,7 @@
     {
       "label": "pytest: Run single scenario — update (overwrite)",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; SNAPSHOT_UPDATE=1 .venv/bin/pytest tests/visual/test_scenarios.py -k '${input:scenarioId}'",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; SNAPSHOT_UPDATE=1 .venv/bin/pytest tests/visual/test_scenarios.py -k '${input:scenarioId}'",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -138,7 +143,7 @@
     {
       "label": "pytest: Run single doc image — generate / verify",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; .venv/bin/pytest tests/visual/test_doc_images.py -k '${input:scenarioId}'",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; .venv/bin/pytest tests/visual/test_doc_images.py -k '${input:scenarioId}'",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -149,7 +154,7 @@
     {
       "label": "pytest: Run single doc image — update (overwrite)",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; DOC_IMAGE_UPDATE=1 .venv/bin/pytest tests/visual/test_doc_images.py -k '${input:scenarioId}'",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; DOC_IMAGE_UPDATE=1 .venv/bin/pytest tests/visual/test_doc_images.py -k '${input:scenarioId}'",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -165,7 +170,7 @@
     {
       "label": "pytest: Doc images — generate / verify",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; .venv/bin/pytest tests/visual/test_doc_images.py",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; .venv/bin/pytest tests/visual/test_doc_images.py",
       "group": "test",
       "problemMatcher": [],
       "presentation": {
@@ -176,7 +181,7 @@
     {
       "label": "pytest: Doc images — update all (overwrite)",
       "type": "shell",
-      "command": ". .ha_env 2>/dev/null; DOC_IMAGE_UPDATE=1 .venv/bin/pytest tests/visual/test_doc_images.py",
+      "command": ". \"${workspaceFolder}/.ha_env\" 2>/dev/null; DOC_IMAGE_UPDATE=1 .venv/bin/pytest tests/visual/test_doc_images.py",
       "group": "test",
       "problemMatcher": [],
       "presentation": {


### PR DESCRIPTION
Note to reviewer agents. Any suggestion to remove ${workspaceFolder} from the command has been tested and does not work (and is the actual issue the PR is fixing). Also, as this is updating commands, there will be no attempt to consolidate the commands in any way.