### PR TITLE
fix: restore tile trend-graph when expander starts collapsed

### DIFF
--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -64,6 +64,30 @@ limitations under the License.
             container._element?.dispatchEvent(new CustomEvent('card-visibility-changed', { detail: { value: open }, bubbles: true, composed: false }));
         }
     });
+    let wasOpen = untrack(() => open);
+    $effect(() => {
+        const isOpen = open;
+        // When the expander is first opened, reconnect the child card subtree
+        // once it has a real size. Child cards that rendered while collapsed
+        // can cache a 0x0 geometry: HA's trend-graph tile feature and
+        // hui-graph-base bake their SVG viewBox from clientWidth/clientHeight a
+        // single time and have no ResizeObserver, so the graph never recovers
+        // when later shown. Removing and re-appending the element forces a
+        // disconnect/reconnect of the whole subtree, which makes those
+        // components re-measure and re-render at the correct size.
+        if (container && outerContainer && isOpen && !wasOpen) {
+            const el = container;
+            const parent = outerContainer;
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                if (el.parentElement === parent) {
+                    const next = el.nextSibling;
+                    parent.removeChild(el);
+                    parent.insertBefore(el, next);
+                }
+            }));
+        }
+        wasOpen = isOpen;
+    });
 
     onMount(async () => {
         const el: HuiCard = document.createElement('hui-card') as HuiCard;

--- a/tests/plugins.yaml
+++ b/tests/plugins.yaml
@@ -15,3 +15,11 @@
 
 - local_path: ../dist/expander-card.js
   filename: expander-card.js
+
+# Third-party card used by the trend-graph regression scenario
+# (expander_08_trend_graph_autoentities): auto-entities keeps its child tiles
+# mounted at 0x0 while the expander is collapsed, which is what triggers the
+# HA trend-graph "no graph after expanding" bug the expander now works around.
+- repo: thomasloven/lovelace-auto-entities
+  asset: auto-entities.js
+  filename: auto-entities.js

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -13,6 +13,9 @@ calls to ``load_all_scenarios()`` / ``load_all_doc_image_scenarios()`` run.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
+from playwright.sync_api import Page
 
 import ha_testcontainer.visual.scenario_runner as _sr
 
@@ -22,3 +25,55 @@ _sr.SCENARIOS_DIR = Path(__file__).parent / "scenarios"
 _sr.SNAPSHOTS_DIR = Path(__file__).parent / "snapshots"
 _sr.REPO_ROOT = _REPO_ROOT
 _sr.DOCS_SCENARIOS_DIR = _REPO_ROOT / "docs" / "scenarios"
+
+
+# ---------------------------------------------------------------------------
+# Custom assertion: trend_graph_rendered
+# ---------------------------------------------------------------------------
+# HA's trend-graph tile feature (and the hui-graph-base it renders) bake their
+# SVG ``viewBox`` from ``clientWidth``/``clientHeight`` a single time and have no
+# ResizeObserver.  When a child card renders while an expander is collapsed it is
+# measured at 0x0, so the graph falls back to ``viewBox="0 0 500 100"`` and never
+# recovers when shown — the graph is invisible.  This assertion fails if any
+# trend-graph in the page still carries that broken zero-size geometry.
+_TREND_GRAPH_PROBE_JS = r"""
+() => {
+  function* walk(root) {
+    for (const el of root.querySelectorAll('*')) {
+      yield el;
+      if (el.shadowRoot) yield* walk(el.shadowRoot);
+    }
+  }
+  const out = [];
+  for (const el of walk(document)) {
+    if (el.tagName && el.tagName.toLowerCase() === 'hui-trend-graph-card-feature') {
+      const gb = el.shadowRoot && el.shadowRoot.querySelector('hui-graph-base');
+      const svg = gb && gb.shadowRoot && gb.shadowRoot.querySelector('svg');
+      out.push({
+        entity: el.context && el.context.entity_id,
+        gbWidth: gb ? gb.clientWidth : 0,
+        viewBox: svg ? svg.getAttribute('viewBox') : null,
+      });
+    }
+  }
+  return out;
+}
+"""
+
+
+def _assert_trend_graph_rendered(page: Page, assertion: dict[str, Any]) -> None:
+    """Fail if any trend-graph has the broken zero-size fallback geometry."""
+    __tracebackhide__ = True
+    min_features = int(assertion.get("min_features", 1))
+    graphs = page.evaluate(_TREND_GRAPH_PROBE_JS)
+    assert len(graphs) >= min_features, (
+        f"Expected at least {min_features} trend-graph feature(s), found {len(graphs)}: {graphs}"
+    )
+    broken = [g for g in graphs if g["gbWidth"] == 0 or g["viewBox"] == "0 0 500 100"]
+    assert not broken, (
+        "trend-graph(s) rendered with zero-size fallback geometry "
+        f"(viewBox '0 0 500 100' / width 0) — graph would be invisible: {broken}"
+    )
+
+
+_sr.register_assertion_type("trend_graph_rendered", _assert_trend_graph_rendered)

--- a/tests/visual/scenarios/expander/expander_08_trend_graph_autoentities.yaml
+++ b/tests/visual/scenarios/expander/expander_08_trend_graph_autoentities.yaml
@@ -1,0 +1,55 @@
+id: expander_trend_graph_autoentities
+description: "Tile trend-graph features inside auto-entities recover their size when a collapsed expander is opened"
+view_path: expander-trend-graph
+
+# Regression test for the trend-graph "no graph after expanding" bug.
+# auto-entities keeps its child tiles mounted at 0x0 while the expander is
+# collapsed; HA's trend-graph feature/hui-graph-base bake their SVG viewBox once
+# from clientWidth/clientHeight and have no ResizeObserver, so without the
+# Card.svelte reconnect-on-open workaround the graphs stay at the broken
+# "0 0 500 100" fallback (invisible) after the expander is opened.
+card:
+  type: custom:expander-card
+  title: Sensors
+  expanded: false
+  cards:
+    - type: custom:auto-entities
+      card:
+        type: grid
+        square: false
+        columns: 1
+      card_param: cards
+      filter:
+        include:
+          - entity_id: sensor.outside_temperature
+            options:
+              type: tile
+              features_position: inline
+              vertical: false
+              features:
+                - type: trend-graph
+                  hours_to_show: 24
+                  detail: true
+          - entity_id: sensor.outside_humidity
+            options:
+              type: tile
+              features_position: inline
+              vertical: false
+              features:
+                - type: trend-graph
+                  hours_to_show: 24
+                  detail: true
+
+interactions:
+  - type: click
+    root: expander-card
+    selector: ".header"
+    settle_ms: 1500
+
+assertions:
+  - type: element_present
+    root: expander-card
+    selector: ".children-container.open"
+
+  - type: trend_graph_rendered
+    min_features: 2


### PR DESCRIPTION
## Problem

When an expander starts collapsed and contains tile cards with a `trend-graph` feature, the graphs are missing/invisible after the card is expanded.

**Root cause** (confirmed against HA 2026.5.1): HA's `trend-graph` tile feature and `hui-graph-base` compute their SVG geometry (`viewBox`, coordinates) from `clientWidth`/`clientHeight` a *single* time and have **no `ResizeObserver`**. Child cards that render while the expander is collapsed get measured at `0×0`, so the graph falls back to `viewBox="0 0 500 100"` and never recovers once shown — the sparkline stays invisible.

This is triggered by wrappers such as **`auto-entities`** that keep their child tiles mounted at `0×0` while collapsed. Core `grid` / `vertical-stack` detach from the DOM cleanly and are unaffected.

## Fix

When the expander transitions from closed → open, reconnect the child card subtree (remove + re-append the `hui-card`) once it has a real size, via a double `requestAnimationFrame`. The disconnect/reconnect forces those no-`ResizeObserver` components to re-measure and re-render at the correct dimensions.

## Tests

- New visual scenario `expander_08_trend_graph_autoentities` reproduces the bug through `auto-entities`, plus a `trend_graph_rendered` assertion that fails on the zero-size fallback geometry.
- `auto-entities` added to `tests/plugins.yaml` (needed to faithfully reproduce the bug in the suite).
- Verified against HA 2026.5.1: the scenario **fails without** the fix (`viewBox "0 0 500 100"`) and **passes with** it. All existing expander scenarios still pass.

Note: the deeper fix would be an upstream `ResizeObserver` in HA's `hui-graph-base`; this is a robust workaround on the expander side.